### PR TITLE
Clean local repository URL in GetRepositoryByRemoteURL

### DIFF
--- a/api/repository.go
+++ b/api/repository.go
@@ -4,6 +4,9 @@ import (
 	"encoding/json"
 	"io/ioutil"
 	"net/http"
+	"regexp"
+	"strings"
+
 	"qovery.go/util"
 )
 
@@ -31,7 +34,21 @@ func GetRepositoryByCurrentRemoteURL(projectId string) Repository {
 	return Repository{}
 }
 
+func cleanRepositoryURL(url string) string {
+	if !strings.HasSuffix(url, ".git") {
+		url = url + ".git"
+	}
+
+	re := regexp.MustCompile("https:\\/\\/(.*@)")
+	match := re.FindStringSubmatch(url)
+	if len(match) == 2 {
+		url = strings.Replace(url, match[1], "", 1)
+	}
+	return url
+}
+
 func GetRepositoryByRemoteURL(projectId string, url string) Repository {
+	url = cleanRepositoryURL(url)
 	for _, v := range ListRepositories(projectId).Results {
 		if v.URL == url {
 			return v


### PR DESCRIPTION
This fixes the retrieval of environment variables during `qovery run` for the following case:

The local current repository URL (git remote origin) can be tweaked by the local CLI user.

For example, it can:
 - contain an auth access token
 - miss the trailing .git

 ex: https://(optional-auth-token@)github.com/user/repo(.git)

We now attempt to remove these tweaks before comparing with URL candidates provided by the Qovery API.