### PR TITLE
open logs in browser

### DIFF
--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -16,4 +16,5 @@ var (
 	OutputEnvironmentVariables bool
 	Tail                       int
 	ConfigurationDirectoryRoot string
+	OpenInBrowserFlag          bool
 )

--- a/cmd/log.go
+++ b/cmd/log.go
@@ -33,6 +33,7 @@ func init() {
 	logCmd.PersistentFlags().IntVar(&Tail, "tail", 0, "Specify if the logs should be streamed")
 	logCmd.PersistentFlags().BoolVarP(&FollowFlag, "follow", "f", false, "Specify if the logs should be streamed")
 	logCmd.PersistentFlags().BoolVarP(&EnvironmentFlag, "environment", "e", false, "Display logs from all apps in the environment")
+	logCmd.PersistentFlags().BoolVarP(&OpenInBrowserFlag, "tab", "t", false, "Open logs url in a new tab in the browser")
 
 	RootCmd.AddCommand(logCmd)
 }
@@ -46,9 +47,12 @@ func ShowApplicationLog(organizationName string, projectName string, branchName 
 
 	logUrl := "https://console.qovery.com/platform/organization/" + orgId + "/projects/" + projectId + "/" + environment.Id + "/" + application.Id + "/logs"
 
-	io.PrintHint("Opening the logs in your browser : " + logUrl)
-
-	_ = browser.OpenURL(logUrl)
+	if OpenInBrowserFlag {
+		io.PrintHint("Opening the logs in your browser : " + logUrl)
+		_ = browser.OpenURL(logUrl)
+	} else {
+		io.PrintHint("View logs in the UI: " + logUrl)
+	}
 
 	io.ListApplicationLogs(lastLines, follow, projectId, environment.Id, application.Id)
 }

--- a/cmd/log.go
+++ b/cmd/log.go
@@ -48,7 +48,7 @@ func ShowApplicationLog(organizationName string, projectName string, branchName 
 
 	io.PrintHint("Opening the logs in your browser : " + logUrl)
 
-	browser.OpenURL(logUrl)
+	_ = browser.OpenURL(logUrl)
 
 	io.ListApplicationLogs(lastLines, follow, projectId, environment.Id, application.Id)
 }

--- a/cmd/log.go
+++ b/cmd/log.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"github.com/spf13/cobra"
+	"github.com/pkg/browser"
 	"qovery-cli/io"
 )
 
@@ -43,7 +44,11 @@ func ShowApplicationLog(organizationName string, projectName string, branchName 
 	environment := io.GetEnvironmentByName(projectId, branchName, true)
 	application := io.GetApplicationByName(projectId, environment.Id, applicationName, true)
 
-	io.PrintHint("View the logs in the UI: " + "https://console.qovery.com/platform/organization/" + orgId + "/projects/" + projectId + "/" + environment.Id + "/" + application.Id + "/logs")
+	logUrl := "https://console.qovery.com/platform/organization/" + orgId + "/projects/" + projectId + "/" + environment.Id + "/" + application.Id + "/logs"
+
+	io.PrintHint("Opening the logs in your browser : " + logUrl)
+
+	browser.OpenURL(logUrl)
 
 	io.ListApplicationLogs(lastLines, follow, projectId, environment.Id, application.Id)
 }


### PR DESCRIPTION
I submit this PR regarding this issue i created : https://github.com/Qovery/qovery-cli/issues/49

The url opens on the browser instead of just being hinted.