### PR TITLE
Fix potential invalid memory in ClientOptions.BeforeSend

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -46,7 +46,13 @@ func initSentry() {
 		// Useful when getting started or trying to figure something out.
 		Debug: false,
 		BeforeSend: func(event *sentry.Event, hint *sentry.EventHint) *sentry.Event {
-			if len(event.Exception) > 0 && len(event.Exception[0].Stacktrace.Frames) > 0 {
+			if event.Exception == nil {
+				return event
+			}
+			if len(event.Exception) > 0 && (event.Exception[0].Stacktrace == nil || event.Exception[0].Stacktrace.Frames == nil) {
+				return event
+			}
+			if len(event.Exception[0].Stacktrace.Frames) > 0 {
 				frames := event.Exception[0].Stacktrace.Frames
 				event.Exception[0].Stacktrace.Frames = frames[:len(frames)-1]
 				frames = event.Exception[0].Stacktrace.Frames


### PR DESCRIPTION
An issue was reported indicating an invalid memory address or nil pointer
dereference according to the stacktrace:
```
qovery-cli/cmd.initSentry.func1(0xc00012edc0, 0xc0002ac240)
qovery-cli/qovery-cli/cmd/root.go:49 +0x2d
```

As the Stacktrace reference can technicaly be null (see `stacktrace.go`),
added some defensive checks on BeforeSend function