### PR TITLE
Add Nix support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,10 @@ dist/
 bin
 qovery
 qovery-cli
+
+# Nix
+result
+
+# Direnv
+.envrc
+.direnv/

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,11 @@
+# https://github.com/edolstra/flake-compat
+(import
+  (
+    let lock = builtins.fromJSON (builtins.readFile ./flake.lock); in
+    fetchTarball {
+      url = "https://github.com/edolstra/flake-compat/archive/${lock.nodes.flake-compat.locked.rev}.tar.gz";
+      sha256 = lock.nodes.flake-compat.locked.narHash;
+    }
+  )
+  { src = ./.; }
+).defaultNix

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,60 @@
+{
+  "nodes": {
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1627913399,
+        "narHash": "sha256-hY8g6H2KFL8ownSiFeMOjwPC8P0ueXpCVEbxgda3pko=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "12c64ca55c1014cdc1b16ed5a804aa8576601ff2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1653936696,
+        "narHash": "sha256-M6bJShji9AIDZ7Kh7CPwPBPb/T7RiVev2PAcOi4fxDQ=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "ce6aa13369b667ac2542593170993504932eb836",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "22.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "nixpkgs": "nixpkgs",
+        "utils": "utils"
+      }
+    },
+    "utils": {
+      "locked": {
+        "lastModified": 1623875721,
+        "narHash": "sha256-A8BU7bjS5GirpAUv4QA+QnJ4CceLHkcXdRp4xITDB0s=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "f7e004a55b120c02ecb6219596820fcd32ca8772",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,48 @@
+{
+  description = "Qovery Command Line Interface";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/22.05";
+    utils.url = "github:numtide/flake-utils";
+    flake-compat = {
+      url = "github:edolstra/flake-compat";
+      flake = false;
+    };
+  };
+
+  outputs = { self, nixpkgs, utils, ... }:
+    utils.lib.eachDefaultSystem
+      (system:
+        let
+          pkgs = import nixpkgs { inherit system; };
+          name = "qovery-cli";
+          version = "0.45.0"; # TODO: find a way to take the version from sources directly
+          vendorSha256 = "KHLknBymDAwr7OxS2Ysx6WU5KQ9kmw0bE2Hlp3CBW0c=";
+
+        in
+        rec {
+          # nix build
+          defaultPackage = pkgs.buildGoModule rec {
+            inherit version vendorSha256;
+            pname = name;
+            src = ./.;
+          };
+
+          # nix run
+          defaultApp = utils.lib.mkApp {
+            inherit name;
+            drv = defaultPackage;
+          };
+
+          # nix develop
+          devShell = pkgs.mkShell {
+            inputsFrom = builtins.attrValues self.defaultPackage;
+            nativeBuildInputs = with pkgs; [
+              # Nix LSP + formatter
+              rnix-lsp
+              nixpkgs-fmt
+            ];
+          };
+        }
+      );
+}

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,11 @@
+# https://github.com/edolstra/flake-compat
+(import
+  (
+    let lock = builtins.fromJSON (builtins.readFile ./flake.lock); in
+    fetchTarball {
+      url = "https://github.com/edolstra/flake-compat/archive/${lock.nodes.flake-compat.locked.rev}.tar.gz";
+      sha256 = lock.nodes.flake-compat.locked.narHash;
+    }
+  )
+  { src = ./.; }
+).shellNix


### PR DESCRIPTION
Hi Qovery :wave:,

I work at [Piana](https://github.com/getpiana) and we use [Nix](https://nixos.org/) to build our development environment. We also use your services for the deployment. We recently needed to use your CLI, so I integrated it inside our development environment. I decided to share the configuration so other Nix users could use it directly. Also, it could be nice to add the derivation to the [nixpkgs](https://github.com/NixOS/nixpkgs): this way your CLI could be accessible directly from their packages instead of building it. Let me know what you think about it.