### PR TITLE
lint: staticcheck false positive fix

### DIFF
--- a/cmd/admin_k9s.go
+++ b/cmd/admin_k9s.go
@@ -1,12 +1,13 @@
 package cmd
 
 import (
+	"os"
+	"os/exec"
+
 	"github.com/qovery/qovery-cli/pkg"
 	"github.com/qovery/qovery-cli/utils"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	"os"
-	"os/exec"
 )
 
 var k9sCmd = &cobra.Command{
@@ -58,10 +59,12 @@ func checkEnv() {
 	if _, ok := os.LookupEnv("VAULT_ADDR"); !ok {
 		log.Error("You must set vault address env variable (VAULT_ADDR).")
 		os.Exit(1)
+		panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 	}
 
 	if _, ok := os.LookupEnv("VAULT_TOKEN"); !ok {
 		log.Error("You must set vault token env variable (VAULT_TOKEN).")
 		os.Exit(1)
+		panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 	}
 }

--- a/cmd/admin_vault_token.go
+++ b/cmd/admin_vault_token.go
@@ -2,11 +2,12 @@ package cmd
 
 import (
 	"fmt"
-	log "github.com/sirupsen/logrus"
-	"github.com/spf13/cobra"
 	"os"
 	"os/exec"
 	"time"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
 )
 
 var vaultTokenCmd = &cobra.Command{
@@ -31,6 +32,7 @@ func getTokenFilePath() string {
 	if err != nil {
 		log.Error("Can't get home directory")
 		os.Exit(1)
+		panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 	}
 	return fmt.Sprintf("%s/.vault-token", homeDir)
 }
@@ -61,6 +63,7 @@ func getVaultToken(args []string) (string, string) {
 		if err != nil {
 			log.Error("error with Vault: " + err.Error())
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		err = os.WriteFile(tokenFilePath, []byte(secret), 0600)
@@ -68,6 +71,7 @@ func getVaultToken(args []string) (string, string) {
 			log.Error(fmt.Sprintf("error while writing token to vault token file (%s)", tokenFilePath))
 			log.Error(err)
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 	}
 
@@ -75,6 +79,7 @@ func getVaultToken(args []string) (string, string) {
 	if err != nil {
 		log.Error(fmt.Sprintf("can't read file %s", tokenFilePath))
 		os.Exit(1)
+		panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 	}
 
 	return tokenFilePath, string(vaultToken)
@@ -84,18 +89,21 @@ func checkVaultEnv() (string, string) {
 	if _, ok := os.LookupEnv("VAULT_ADDR"); !ok {
 		log.Error("You must set vault address env variable (VAULT_ADDR).")
 		os.Exit(1)
+		panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 	}
 
 	ghToken, err := os.LookupEnv("VAULT_GH_TOKEN")
 	if !err {
 		log.Error("You must set your personal token env variable (VAULT_GH_TOKEN).")
 		os.Exit(1)
+		panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 	}
 
 	vaultPath, e := exec.LookPath("vault")
 	if e != nil {
 		log.Error("vault binary is not found in your path")
 		os.Exit(1)
+		panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 	}
 
 	return vaultPath, ghToken

--- a/cmd/application_delete.go
+++ b/cmd/application_delete.go
@@ -3,10 +3,11 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"os"
+
 	"github.com/pterm/pterm"
 	"github.com/qovery/qovery-cli/utils"
 	"github.com/spf13/cobra"
-	"os"
 )
 
 var applicationDeleteCmd = &cobra.Command{
@@ -19,6 +20,7 @@ var applicationDeleteCmd = &cobra.Command{
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		client := utils.GetQoveryClient(tokenType, token)
@@ -27,12 +29,14 @@ var applicationDeleteCmd = &cobra.Command{
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		if !utils.IsEnvironmentInATerminalState(envId, client) {
 			utils.PrintlnError(fmt.Errorf("environment id '%s' is not in a terminal state. The request is not queued and you must wait "+
 				"for the end of the current operation to run your command. Try again in a few moment", envId))
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		applications, _, err := client.ApplicationsApi.ListApplication(context.Background(), envId).Execute()
@@ -40,6 +44,7 @@ var applicationDeleteCmd = &cobra.Command{
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		application := utils.FindByApplicationName(applications.GetResults(), applicationName)
@@ -48,6 +53,7 @@ var applicationDeleteCmd = &cobra.Command{
 			utils.PrintlnError(fmt.Errorf("application %s not found", applicationName))
 			utils.PrintlnInfo("You can list all applications with: qovery application list")
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		_, err = client.ApplicationMainCallsApi.DeleteApplication(context.Background(), application.Id).Execute()
@@ -55,6 +61,7 @@ var applicationDeleteCmd = &cobra.Command{
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		utils.Println(fmt.Sprintf("Deleting application %s in progress..", pterm.FgBlue.Sprintf(applicationName)))

--- a/cmd/application_deploy.go
+++ b/cmd/application_deploy.go
@@ -3,11 +3,12 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"os"
+
 	"github.com/pterm/pterm"
 	"github.com/qovery/qovery-cli/utils"
 	"github.com/qovery/qovery-client-go"
 	"github.com/spf13/cobra"
-	"os"
 )
 
 var applicationDeployCmd = &cobra.Command{
@@ -20,6 +21,7 @@ var applicationDeployCmd = &cobra.Command{
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		client := utils.GetQoveryClient(tokenType, token)
@@ -28,12 +30,14 @@ var applicationDeployCmd = &cobra.Command{
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		if !utils.IsEnvironmentInATerminalState(envId, client) {
 			utils.PrintlnError(fmt.Errorf("environment id '%s' is not in a terminal state. The request is not queued and you must wait "+
 				"for the end of the current operation to run your command. Try again in a few moment", envId))
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		applications, _, err := client.ApplicationsApi.ListApplication(context.Background(), envId).Execute()
@@ -41,6 +45,7 @@ var applicationDeployCmd = &cobra.Command{
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		application := utils.FindByApplicationName(applications.GetResults(), applicationName)
@@ -49,6 +54,7 @@ var applicationDeployCmd = &cobra.Command{
 			utils.PrintlnError(fmt.Errorf("application %s not found", applicationName))
 			utils.PrintlnInfo("You can list all applications with: qovery application list")
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		req := qovery.DeployRequest{
@@ -66,6 +72,7 @@ var applicationDeployCmd = &cobra.Command{
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		utils.Println(fmt.Sprintf("Deploying application %s in progress..", pterm.FgBlue.Sprintf(applicationName)))

--- a/cmd/application_list.go
+++ b/cmd/application_list.go
@@ -2,9 +2,10 @@ package cmd
 
 import (
 	"context"
+	"os"
+
 	"github.com/qovery/qovery-cli/utils"
 	"github.com/spf13/cobra"
-	"os"
 )
 
 var applicationListCmd = &cobra.Command{
@@ -17,6 +18,7 @@ var applicationListCmd = &cobra.Command{
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		client := utils.GetQoveryClient(tokenType, token)
@@ -26,6 +28,7 @@ var applicationListCmd = &cobra.Command{
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		applications, _, err := client.ApplicationsApi.ListApplication(context.Background(), envId).Execute()
@@ -33,6 +36,7 @@ var applicationListCmd = &cobra.Command{
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		statuses, _, err := client.EnvironmentMainCallsApi.GetEnvironmentStatuses(context.Background(), envId).Execute()
@@ -40,6 +44,7 @@ var applicationListCmd = &cobra.Command{
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		var data [][]string
@@ -54,6 +59,7 @@ var applicationListCmd = &cobra.Command{
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 	},
 }

--- a/cmd/application_redeploy.go
+++ b/cmd/application_redeploy.go
@@ -3,10 +3,11 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"os"
+
 	"github.com/pterm/pterm"
 	"github.com/qovery/qovery-cli/utils"
 	"github.com/spf13/cobra"
-	"os"
 )
 
 var applicationRedeployCmd = &cobra.Command{
@@ -19,6 +20,7 @@ var applicationRedeployCmd = &cobra.Command{
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		client := utils.GetQoveryClient(tokenType, token)
@@ -27,12 +29,14 @@ var applicationRedeployCmd = &cobra.Command{
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		if !utils.IsEnvironmentInATerminalState(envId, client) {
 			utils.PrintlnError(fmt.Errorf("environment id '%s' is not in a terminal state. The request is not queued and you must wait "+
 				"for the end of the current operation to run your command. Try again in a few moment", envId))
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		applications, _, err := client.ApplicationsApi.ListApplication(context.Background(), envId).Execute()
@@ -40,6 +44,7 @@ var applicationRedeployCmd = &cobra.Command{
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		application := utils.FindByApplicationName(applications.GetResults(), applicationName)
@@ -48,6 +53,7 @@ var applicationRedeployCmd = &cobra.Command{
 			utils.PrintlnError(fmt.Errorf("application %s not found", applicationName))
 			utils.PrintlnInfo("You can list all applications with: qovery application list")
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		_, _, err = client.ApplicationActionsApi.RestartApplication(context.Background(), application.Id).Execute()
@@ -55,6 +61,7 @@ var applicationRedeployCmd = &cobra.Command{
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		utils.Println(fmt.Sprintf("Redeploying application %s in progress..", pterm.FgBlue.Sprintf(applicationName)))

--- a/cmd/application_stop.go
+++ b/cmd/application_stop.go
@@ -3,10 +3,11 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"os"
+
 	"github.com/pterm/pterm"
 	"github.com/qovery/qovery-cli/utils"
 	"github.com/spf13/cobra"
-	"os"
 )
 
 var applicationStopCmd = &cobra.Command{
@@ -19,6 +20,7 @@ var applicationStopCmd = &cobra.Command{
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		client := utils.GetQoveryClient(tokenType, token)
@@ -27,12 +29,14 @@ var applicationStopCmd = &cobra.Command{
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		if !utils.IsEnvironmentInATerminalState(envId, client) {
 			utils.PrintlnError(fmt.Errorf("environment id '%s' is not in a terminal state. The request is not queued and you must wait "+
 				"for the end of the current operation to run your command. Try again in a few moment", envId))
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		applications, _, err := client.ApplicationsApi.ListApplication(context.Background(), envId).Execute()
@@ -40,6 +44,7 @@ var applicationStopCmd = &cobra.Command{
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		application := utils.FindByApplicationName(applications.GetResults(), applicationName)
@@ -48,6 +53,7 @@ var applicationStopCmd = &cobra.Command{
 			utils.PrintlnError(fmt.Errorf("application %s not found", applicationName))
 			utils.PrintlnInfo("You can list all applications with: qovery application list")
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		_, _, err = client.ApplicationActionsApi.StopApplication(context.Background(), application.Id).Execute()
@@ -55,6 +61,7 @@ var applicationStopCmd = &cobra.Command{
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		utils.Println(fmt.Sprintf("Stopping application %s in progress..", pterm.FgBlue.Sprintf(applicationName)))

--- a/cmd/application_update.go
+++ b/cmd/application_update.go
@@ -3,11 +3,12 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"os"
+
 	"github.com/pterm/pterm"
 	"github.com/qovery/qovery-cli/utils"
 	"github.com/qovery/qovery-client-go"
 	"github.com/spf13/cobra"
-	"os"
 )
 
 var applicationUpdateCmd = &cobra.Command{
@@ -20,6 +21,7 @@ var applicationUpdateCmd = &cobra.Command{
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		client := utils.GetQoveryClient(tokenType, token)
@@ -28,12 +30,14 @@ var applicationUpdateCmd = &cobra.Command{
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		if !utils.IsEnvironmentInATerminalState(envId, client) {
 			utils.PrintlnError(fmt.Errorf("environment id '%s' is not in a terminal state. The request is not queued and you must wait "+
 				"for the end of the current operation to run your command. Try again in a few moment", envId))
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		applications, _, err := client.ApplicationsApi.ListApplication(context.Background(), envId).Execute()
@@ -41,6 +45,7 @@ var applicationUpdateCmd = &cobra.Command{
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		application := utils.FindByApplicationName(applications.GetResults(), applicationName)
@@ -49,6 +54,7 @@ var applicationUpdateCmd = &cobra.Command{
 			utils.PrintlnError(fmt.Errorf("application %s not found", applicationName))
 			utils.PrintlnInfo("You can list all applications with: qovery application list")
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		var storage []qovery.ServiceStorageRequestStorageInner
@@ -90,6 +96,7 @@ var applicationUpdateCmd = &cobra.Command{
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		utils.Println(fmt.Sprintf("Application %s updated!", pterm.FgBlue.Sprintf(applicationName)))

--- a/cmd/container_delete.go
+++ b/cmd/container_delete.go
@@ -3,10 +3,11 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"os"
+
 	"github.com/pterm/pterm"
 	"github.com/qovery/qovery-cli/utils"
 	"github.com/spf13/cobra"
-	"os"
 )
 
 var containerDeleteCmd = &cobra.Command{
@@ -19,6 +20,7 @@ var containerDeleteCmd = &cobra.Command{
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		client := utils.GetQoveryClient(tokenType, token)
@@ -27,12 +29,14 @@ var containerDeleteCmd = &cobra.Command{
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		if !utils.IsEnvironmentInATerminalState(envId, client) {
 			utils.PrintlnError(fmt.Errorf("environment id '%s' is not in a terminal state. The request is not queued and you must wait "+
 				"for the end of the current operation to run your command. Try again in a few moment", envId))
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		containers, _, err := client.ContainersApi.ListContainer(context.Background(), envId).Execute()
@@ -40,6 +44,7 @@ var containerDeleteCmd = &cobra.Command{
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		container := utils.FindByContainerName(containers.GetResults(), containerName)
@@ -48,6 +53,7 @@ var containerDeleteCmd = &cobra.Command{
 			utils.PrintlnError(fmt.Errorf("container %s not found", containerName))
 			utils.PrintlnInfo("You can list all containers with: qovery container list")
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		_, err = client.ContainerMainCallsApi.DeleteContainer(context.Background(), container.Id).Execute()
@@ -55,6 +61,7 @@ var containerDeleteCmd = &cobra.Command{
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		utils.Println(fmt.Sprintf("Deleting container %s in progress..", pterm.FgBlue.Sprintf(containerName)))

--- a/cmd/container_deploy.go
+++ b/cmd/container_deploy.go
@@ -3,11 +3,12 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"os"
+
 	"github.com/pterm/pterm"
 	"github.com/qovery/qovery-cli/utils"
 	"github.com/qovery/qovery-client-go"
 	"github.com/spf13/cobra"
-	"os"
 )
 
 var containerDeployCmd = &cobra.Command{
@@ -20,6 +21,7 @@ var containerDeployCmd = &cobra.Command{
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		client := utils.GetQoveryClient(tokenType, token)
@@ -28,12 +30,14 @@ var containerDeployCmd = &cobra.Command{
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		if !utils.IsEnvironmentInATerminalState(envId, client) {
 			utils.PrintlnError(fmt.Errorf("environment id '%s' is not in a terminal state. The request is not queued and you must wait "+
 				"for the end of the current operation to run your command. Try again in a few moment", envId))
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		containers, _, err := client.ContainersApi.ListContainer(context.Background(), envId).Execute()
@@ -41,6 +45,7 @@ var containerDeployCmd = &cobra.Command{
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		container := utils.FindByContainerName(containers.GetResults(), containerName)
@@ -49,6 +54,7 @@ var containerDeployCmd = &cobra.Command{
 			utils.PrintlnError(fmt.Errorf("container %s not found", containerName))
 			utils.PrintlnInfo("You can list all containers with: qovery container list")
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		req := qovery.ContainerDeployRequest{
@@ -64,6 +70,7 @@ var containerDeployCmd = &cobra.Command{
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		utils.Println(fmt.Sprintf("Deploying container %s in progress..", pterm.FgBlue.Sprintf(containerName)))

--- a/cmd/container_list.go
+++ b/cmd/container_list.go
@@ -2,9 +2,10 @@ package cmd
 
 import (
 	"context"
+	"os"
+
 	"github.com/qovery/qovery-cli/utils"
 	"github.com/spf13/cobra"
-	"os"
 )
 
 var containerListCmd = &cobra.Command{
@@ -17,6 +18,7 @@ var containerListCmd = &cobra.Command{
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		client := utils.GetQoveryClient(tokenType, token)
@@ -25,6 +27,7 @@ var containerListCmd = &cobra.Command{
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		containers, _, err := client.ContainersApi.ListContainer(context.Background(), envId).Execute()
@@ -32,6 +35,7 @@ var containerListCmd = &cobra.Command{
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		statuses, _, err := client.EnvironmentMainCallsApi.GetEnvironmentStatuses(context.Background(), envId).Execute()
@@ -39,6 +43,7 @@ var containerListCmd = &cobra.Command{
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		var data [][]string
@@ -53,6 +58,7 @@ var containerListCmd = &cobra.Command{
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 	},
 }

--- a/cmd/container_redeploy.go
+++ b/cmd/container_redeploy.go
@@ -3,10 +3,11 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"os"
+
 	"github.com/pterm/pterm"
 	"github.com/qovery/qovery-cli/utils"
 	"github.com/spf13/cobra"
-	"os"
 )
 
 var containerRedeployCmd = &cobra.Command{
@@ -19,6 +20,7 @@ var containerRedeployCmd = &cobra.Command{
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		client := utils.GetQoveryClient(tokenType, token)
@@ -27,12 +29,14 @@ var containerRedeployCmd = &cobra.Command{
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		if !utils.IsEnvironmentInATerminalState(envId, client) {
 			utils.PrintlnError(fmt.Errorf("environment id '%s' is not in a terminal state. The request is not queued and you must wait "+
 				"for the end of the current operation to run your command. Try again in a few moment", envId))
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		containers, _, err := client.ContainersApi.ListContainer(context.Background(), envId).Execute()
@@ -40,6 +44,7 @@ var containerRedeployCmd = &cobra.Command{
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		container := utils.FindByContainerName(containers.GetResults(), containerName)
@@ -48,6 +53,7 @@ var containerRedeployCmd = &cobra.Command{
 			utils.PrintlnError(fmt.Errorf("container %s not found", containerName))
 			utils.PrintlnInfo("You can list all containers with: qovery container list")
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		_, _, err = client.ContainerActionsApi.RestartContainer(context.Background(), container.Id).Execute()
@@ -55,6 +61,7 @@ var containerRedeployCmd = &cobra.Command{
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		utils.Println(fmt.Sprintf("Redeploying container %s in progress..", pterm.FgBlue.Sprintf(containerName)))

--- a/cmd/container_stop.go
+++ b/cmd/container_stop.go
@@ -3,10 +3,11 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"os"
+
 	"github.com/pterm/pterm"
 	"github.com/qovery/qovery-cli/utils"
 	"github.com/spf13/cobra"
-	"os"
 )
 
 var containerStopCmd = &cobra.Command{
@@ -19,6 +20,7 @@ var containerStopCmd = &cobra.Command{
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		client := utils.GetQoveryClient(tokenType, token)
@@ -27,12 +29,14 @@ var containerStopCmd = &cobra.Command{
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		if !utils.IsEnvironmentInATerminalState(envId, client) {
 			utils.PrintlnError(fmt.Errorf("environment id '%s' is not in a terminal state. The request is not queued and you must wait "+
 				"for the end of the current operation to run your command. Try again in a few moment", envId))
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		containers, _, err := client.ContainersApi.ListContainer(context.Background(), envId).Execute()
@@ -40,6 +44,7 @@ var containerStopCmd = &cobra.Command{
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		container := utils.FindByContainerName(containers.GetResults(), containerName)
@@ -48,6 +53,7 @@ var containerStopCmd = &cobra.Command{
 			utils.PrintlnError(fmt.Errorf("container %s not found", containerName))
 			utils.PrintlnInfo("You can list all containers with: qovery container list")
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		_, _, err = client.ContainerActionsApi.StopContainer(context.Background(), container.Id).Execute()
@@ -55,6 +61,7 @@ var containerStopCmd = &cobra.Command{
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		utils.Println(fmt.Sprintf("Stopping container %s in progress..", pterm.FgBlue.Sprintf(containerName)))

--- a/cmd/cronjob_delete.go
+++ b/cmd/cronjob_delete.go
@@ -3,9 +3,10 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"os"
+
 	"github.com/qovery/qovery-cli/utils"
 	"github.com/spf13/cobra"
-	"os"
 )
 
 var cronjobDeleteCmd = &cobra.Command{
@@ -18,6 +19,7 @@ var cronjobDeleteCmd = &cobra.Command{
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		client := utils.GetQoveryClient(tokenType, token)
@@ -26,12 +28,14 @@ var cronjobDeleteCmd = &cobra.Command{
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		if !utils.IsEnvironmentInATerminalState(envId, client) {
 			utils.PrintlnError(fmt.Errorf("environment id '%s' is not in a terminal state. The request is not queued and you must wait "+
 				"for the end of the current operation to run your command. Try again in a few moment", envId))
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		cronjobs, err := ListCronjobs(envId, client)
@@ -39,6 +43,7 @@ var cronjobDeleteCmd = &cobra.Command{
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		job := utils.FindByJobName(cronjobs, cronjobName)
@@ -47,6 +52,7 @@ var cronjobDeleteCmd = &cobra.Command{
 			utils.PrintlnError(fmt.Errorf("job %s not found", cronjobName))
 			utils.PrintlnInfo("You can list all cronjobs with: qovery cronjob list")
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		_, err = client.JobMainCallsApi.DeleteJob(context.Background(), job.Id).Execute()
@@ -54,6 +60,7 @@ var cronjobDeleteCmd = &cobra.Command{
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		utils.Println("Cronjob is deleting!")

--- a/cmd/cronjob_deploy.go
+++ b/cmd/cronjob_deploy.go
@@ -3,10 +3,11 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"os"
+
 	"github.com/qovery/qovery-cli/utils"
 	"github.com/qovery/qovery-client-go"
 	"github.com/spf13/cobra"
-	"os"
 )
 
 var cronjobDeployCmd = &cobra.Command{
@@ -19,6 +20,7 @@ var cronjobDeployCmd = &cobra.Command{
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		client := utils.GetQoveryClient(tokenType, token)
@@ -27,12 +29,14 @@ var cronjobDeployCmd = &cobra.Command{
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		if !utils.IsEnvironmentInATerminalState(envId, client) {
 			utils.PrintlnError(fmt.Errorf("environment id '%s' is not in a terminal state. The request is not queued and you must wait "+
 				"for the end of the current operation to run your command. Try again in a few moment", envId))
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		cronjobs, err := ListCronjobs(envId, client)
@@ -40,6 +44,7 @@ var cronjobDeployCmd = &cobra.Command{
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		cronjob := utils.FindByJobName(cronjobs, cronjobName)
@@ -48,6 +53,7 @@ var cronjobDeployCmd = &cobra.Command{
 			utils.PrintlnError(fmt.Errorf("cronjob %s not found", cronjobName))
 			utils.PrintlnInfo("You can list all cronjobs with: qovery cronjob list")
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		docker := cronjob.Source.Docker.Get()
@@ -74,6 +80,7 @@ var cronjobDeployCmd = &cobra.Command{
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		utils.Println("Cronjob is deploying!")

--- a/cmd/cronjob_list.go
+++ b/cmd/cronjob_list.go
@@ -2,9 +2,10 @@ package cmd
 
 import (
 	"context"
+	"os"
+
 	"github.com/qovery/qovery-cli/utils"
 	"github.com/spf13/cobra"
-	"os"
 )
 
 var cronjobListCmd = &cobra.Command{
@@ -17,6 +18,7 @@ var cronjobListCmd = &cobra.Command{
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		client := utils.GetQoveryClient(tokenType, token)
@@ -25,6 +27,7 @@ var cronjobListCmd = &cobra.Command{
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		cronjobs, err := ListCronjobs(envId, client)
@@ -32,6 +35,7 @@ var cronjobListCmd = &cobra.Command{
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		statuses, _, err := client.EnvironmentMainCallsApi.GetEnvironmentStatuses(context.Background(), envId).Execute()
@@ -39,6 +43,7 @@ var cronjobListCmd = &cobra.Command{
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		var data [][]string
@@ -53,6 +58,7 @@ var cronjobListCmd = &cobra.Command{
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 	},
 }

--- a/cmd/cronjob_redeploy.go
+++ b/cmd/cronjob_redeploy.go
@@ -3,9 +3,10 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"os"
+
 	"github.com/qovery/qovery-cli/utils"
 	"github.com/spf13/cobra"
-	"os"
 )
 
 var cronjobRedeployCmd = &cobra.Command{
@@ -18,6 +19,7 @@ var cronjobRedeployCmd = &cobra.Command{
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		client := utils.GetQoveryClient(tokenType, token)
@@ -26,12 +28,14 @@ var cronjobRedeployCmd = &cobra.Command{
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		if !utils.IsEnvironmentInATerminalState(envId, client) {
 			utils.PrintlnError(fmt.Errorf("environment id '%s' is not in a terminal state. The request is not queued and you must wait "+
 				"for the end of the current operation to run your command. Try again in a few moment", envId))
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		cronjobs, err := ListCronjobs(envId, client)
@@ -39,6 +43,7 @@ var cronjobRedeployCmd = &cobra.Command{
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		cronjob := utils.FindByJobName(cronjobs, cronjobName)
@@ -47,6 +52,7 @@ var cronjobRedeployCmd = &cobra.Command{
 			utils.PrintlnError(fmt.Errorf("cronjob %s not found", cronjobName))
 			utils.PrintlnInfo("You can list all cronjobs with: qovery cronjob list")
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		_, _, err = client.JobActionsApi.RestartJob(context.Background(), cronjob.Id).Execute()
@@ -54,6 +60,7 @@ var cronjobRedeployCmd = &cobra.Command{
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		utils.Println("Cronjob is redeploying!")

--- a/cmd/cronjob_stop.go
+++ b/cmd/cronjob_stop.go
@@ -3,9 +3,10 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"os"
+
 	"github.com/qovery/qovery-cli/utils"
 	"github.com/spf13/cobra"
-	"os"
 )
 
 var cronjobStopCmd = &cobra.Command{
@@ -18,6 +19,7 @@ var cronjobStopCmd = &cobra.Command{
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		client := utils.GetQoveryClient(tokenType, token)
@@ -26,12 +28,14 @@ var cronjobStopCmd = &cobra.Command{
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		if !utils.IsEnvironmentInATerminalState(envId, client) {
 			utils.PrintlnError(fmt.Errorf("environment id '%s' is not in a terminal state. The request is not queued and you must wait "+
 				"for the end of the current operation to run your command. Try again in a few moment", envId))
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		cronjobs, err := ListCronjobs(envId, client)
@@ -39,6 +43,7 @@ var cronjobStopCmd = &cobra.Command{
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		cronjob := utils.FindByJobName(cronjobs, cronjobName)
@@ -47,6 +52,7 @@ var cronjobStopCmd = &cobra.Command{
 			utils.PrintlnError(fmt.Errorf("cronjob %s not found", cronjobName))
 			utils.PrintlnInfo("You can list all cronjobs with: qovery cronjob list")
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		_, _, err = client.JobActionsApi.StopJob(context.Background(), cronjob.Id).Execute()
@@ -54,6 +60,7 @@ var cronjobStopCmd = &cobra.Command{
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		utils.Println("Cronjob is stopping!")

--- a/cmd/database_delete.go
+++ b/cmd/database_delete.go
@@ -3,10 +3,11 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"os"
+
 	"github.com/pterm/pterm"
 	"github.com/qovery/qovery-cli/utils"
 	"github.com/spf13/cobra"
-	"os"
 )
 
 var databaseDeleteCmd = &cobra.Command{
@@ -19,6 +20,7 @@ var databaseDeleteCmd = &cobra.Command{
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		client := utils.GetQoveryClient(tokenType, token)
@@ -27,12 +29,14 @@ var databaseDeleteCmd = &cobra.Command{
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		if !utils.IsEnvironmentInATerminalState(envId, client) {
 			utils.PrintlnError(fmt.Errorf("environment id '%s' is not in a terminal state. The request is not queued and you must wait "+
 				"for the end of the current operation to run your command. Try again in a few moment", envId))
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		databases, _, err := client.DatabasesApi.ListDatabase(context.Background(), envId).Execute()
@@ -40,6 +44,7 @@ var databaseDeleteCmd = &cobra.Command{
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		database := utils.FindByDatabaseName(databases.GetResults(), databaseName)
@@ -48,6 +53,7 @@ var databaseDeleteCmd = &cobra.Command{
 			utils.PrintlnError(fmt.Errorf("database %s not found", databaseName))
 			utils.PrintlnInfo("You can list all databases with: qovery database list")
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		_, err = client.DatabaseMainCallsApi.DeleteDatabase(context.Background(), database.Id).Execute()
@@ -55,6 +61,7 @@ var databaseDeleteCmd = &cobra.Command{
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		utils.Println(fmt.Sprintf("Deleting database %s in progress..", pterm.FgBlue.Sprintf(databaseName)))

--- a/cmd/database_deploy.go
+++ b/cmd/database_deploy.go
@@ -3,10 +3,11 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"os"
+
 	"github.com/pterm/pterm"
 	"github.com/qovery/qovery-cli/utils"
 	"github.com/spf13/cobra"
-	"os"
 )
 
 var databaseDeployCmd = &cobra.Command{
@@ -19,6 +20,7 @@ var databaseDeployCmd = &cobra.Command{
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		client := utils.GetQoveryClient(tokenType, token)
@@ -27,12 +29,14 @@ var databaseDeployCmd = &cobra.Command{
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		if !utils.IsEnvironmentInATerminalState(envId, client) {
 			utils.PrintlnError(fmt.Errorf("environment id '%s' is not in a terminal state. The request is not queued and you must wait "+
 				"for the end of the current operation to run your command. Try again in a few moment", envId))
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		databases, _, err := client.DatabasesApi.ListDatabase(context.Background(), envId).Execute()
@@ -40,6 +44,7 @@ var databaseDeployCmd = &cobra.Command{
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		database := utils.FindByDatabaseName(databases.GetResults(), databaseName)
@@ -48,6 +53,7 @@ var databaseDeployCmd = &cobra.Command{
 			utils.PrintlnError(fmt.Errorf("database %s not found", databaseName))
 			utils.PrintlnInfo("You can list all databases with: qovery database list")
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		_, _, err = client.DatabaseActionsApi.DeployDatabase(context.Background(), database.Id).Execute()
@@ -55,6 +61,7 @@ var databaseDeployCmd = &cobra.Command{
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		utils.Println(fmt.Sprintf("Deploying database %s in progress..", pterm.FgBlue.Sprintf(databaseName)))

--- a/cmd/database_list.go
+++ b/cmd/database_list.go
@@ -2,9 +2,10 @@ package cmd
 
 import (
 	"context"
+	"os"
+
 	"github.com/qovery/qovery-cli/utils"
 	"github.com/spf13/cobra"
-	"os"
 )
 
 var databaseListCmd = &cobra.Command{
@@ -17,6 +18,7 @@ var databaseListCmd = &cobra.Command{
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		client := utils.GetQoveryClient(tokenType, token)
@@ -26,6 +28,7 @@ var databaseListCmd = &cobra.Command{
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		databases, _, err := client.DatabasesApi.ListDatabase(context.Background(), envId).Execute()
@@ -33,6 +36,7 @@ var databaseListCmd = &cobra.Command{
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		statuses, _, err := client.EnvironmentMainCallsApi.GetEnvironmentStatuses(context.Background(), envId).Execute()
@@ -40,6 +44,7 @@ var databaseListCmd = &cobra.Command{
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		var data [][]string
@@ -54,6 +59,7 @@ var databaseListCmd = &cobra.Command{
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 	},
 }

--- a/cmd/database_redeploy.go
+++ b/cmd/database_redeploy.go
@@ -3,10 +3,11 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"os"
+
 	"github.com/pterm/pterm"
 	"github.com/qovery/qovery-cli/utils"
 	"github.com/spf13/cobra"
-	"os"
 )
 
 var databaseRedeployCmd = &cobra.Command{
@@ -19,6 +20,7 @@ var databaseRedeployCmd = &cobra.Command{
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		client := utils.GetQoveryClient(tokenType, token)
@@ -27,12 +29,14 @@ var databaseRedeployCmd = &cobra.Command{
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		if !utils.IsEnvironmentInATerminalState(envId, client) {
 			utils.PrintlnError(fmt.Errorf("environment id '%s' is not in a terminal state. The request is not queued and you must wait "+
 				"for the end of the current operation to run your command. Try again in a few moment", envId))
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		databases, _, err := client.DatabasesApi.ListDatabase(context.Background(), envId).Execute()
@@ -40,6 +44,7 @@ var databaseRedeployCmd = &cobra.Command{
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		database := utils.FindByDatabaseName(databases.GetResults(), databaseName)
@@ -48,6 +53,7 @@ var databaseRedeployCmd = &cobra.Command{
 			utils.PrintlnError(fmt.Errorf("database %s not found", databaseName))
 			utils.PrintlnInfo("You can list all databases with: qovery database list")
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		_, _, err = client.DatabaseActionsApi.RestartDatabase(context.Background(), database.Id).Execute()
@@ -55,6 +61,7 @@ var databaseRedeployCmd = &cobra.Command{
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		utils.Println(fmt.Sprintf("Redeploying database %s in progress..", pterm.FgBlue.Sprintf(databaseName)))

--- a/cmd/database_stop.go
+++ b/cmd/database_stop.go
@@ -3,10 +3,11 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"os"
+
 	"github.com/pterm/pterm"
 	"github.com/qovery/qovery-cli/utils"
 	"github.com/spf13/cobra"
-	"os"
 )
 
 var databaseStopCmd = &cobra.Command{
@@ -19,6 +20,7 @@ var databaseStopCmd = &cobra.Command{
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		client := utils.GetQoveryClient(tokenType, token)
@@ -27,12 +29,14 @@ var databaseStopCmd = &cobra.Command{
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		if !utils.IsEnvironmentInATerminalState(envId, client) {
 			utils.PrintlnError(fmt.Errorf("environment id '%s' is not in a terminal state. The request is not queued and you must wait "+
 				"for the end of the current operation to run your command. Try again in a few moment", envId))
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		databases, _, err := client.DatabasesApi.ListDatabase(context.Background(), envId).Execute()
@@ -40,6 +44,7 @@ var databaseStopCmd = &cobra.Command{
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		database := utils.FindByDatabaseName(databases.GetResults(), databaseName)
@@ -48,6 +53,7 @@ var databaseStopCmd = &cobra.Command{
 			utils.PrintlnError(fmt.Errorf("database %s not found", databaseName))
 			utils.PrintlnInfo("You can list all databases with: qovery database list")
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		_, _, err = client.DatabaseActionsApi.StopDatabase(context.Background(), database.Id).Execute()
@@ -55,6 +61,7 @@ var databaseStopCmd = &cobra.Command{
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		utils.Println(fmt.Sprintf("Stopping database %s in progress..", pterm.FgBlue.Sprintf(databaseName)))

--- a/cmd/environment_cancel.go
+++ b/cmd/environment_cancel.go
@@ -2,10 +2,11 @@ package cmd
 
 import (
 	"context"
+	"os"
+
 	"github.com/qovery/qovery-cli/utils"
 	"github.com/qovery/qovery-client-go"
 	"github.com/spf13/cobra"
-	"os"
 )
 
 var environmentCancelCmd = &cobra.Command{
@@ -18,6 +19,7 @@ var environmentCancelCmd = &cobra.Command{
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		client := utils.GetQoveryClient(tokenType, token)
@@ -26,6 +28,7 @@ var environmentCancelCmd = &cobra.Command{
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		_, _, err = client.EnvironmentActionsApi.CancelEnvironmentDeployment(context.Background(), envId).Execute()
@@ -33,6 +36,7 @@ var environmentCancelCmd = &cobra.Command{
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		utils.Println("Environment is canceling!")

--- a/cmd/environment_clone.go
+++ b/cmd/environment_clone.go
@@ -2,11 +2,12 @@ package cmd
 
 import (
 	"context"
+	"os"
+	"strings"
+
 	"github.com/qovery/qovery-cli/utils"
 	"github.com/qovery/qovery-client-go"
 	"github.com/spf13/cobra"
-	"os"
-	"strings"
 )
 
 var newEnvironmentName string
@@ -23,6 +24,7 @@ var environmentCloneCmd = &cobra.Command{
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		client := utils.GetQoveryClient(tokenType, token)
@@ -31,6 +33,7 @@ var environmentCloneCmd = &cobra.Command{
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		req := qovery.CloneRequest{
@@ -66,6 +69,7 @@ var environmentCloneCmd = &cobra.Command{
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		utils.Println("Environment is cloned!")

--- a/cmd/environment_delete.go
+++ b/cmd/environment_delete.go
@@ -3,10 +3,11 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"os"
+
 	"github.com/qovery/qovery-cli/utils"
 	"github.com/qovery/qovery-client-go"
 	"github.com/spf13/cobra"
-	"os"
 )
 
 var environmentDeleteCmd = &cobra.Command{
@@ -19,6 +20,7 @@ var environmentDeleteCmd = &cobra.Command{
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		client := utils.GetQoveryClient(tokenType, token)
@@ -27,12 +29,14 @@ var environmentDeleteCmd = &cobra.Command{
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		if !utils.IsEnvironmentInATerminalState(envId, client) {
 			utils.PrintlnError(fmt.Errorf("environment id '%s' is not in a terminal state. The request is not queued and you must wait "+
 				"for the end of the current operation to run your command. Try again in a few moment", envId))
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		_, err = client.EnvironmentMainCallsApi.DeleteEnvironment(context.Background(), envId).Execute()
@@ -40,6 +44,7 @@ var environmentDeleteCmd = &cobra.Command{
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		utils.Println("Environment is deleting!")

--- a/cmd/environment_deploy.go
+++ b/cmd/environment_deploy.go
@@ -3,10 +3,11 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"os"
+
 	"github.com/qovery/qovery-cli/utils"
 	"github.com/qovery/qovery-client-go"
 	"github.com/spf13/cobra"
-	"os"
 )
 
 var environmentDeployCmd = &cobra.Command{
@@ -19,6 +20,7 @@ var environmentDeployCmd = &cobra.Command{
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		client := utils.GetQoveryClient(tokenType, token)
@@ -27,12 +29,14 @@ var environmentDeployCmd = &cobra.Command{
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		if !utils.IsEnvironmentInATerminalState(envId, client) {
 			utils.PrintlnError(fmt.Errorf("environment id '%s' is not in a terminal state. The request is not queued and you must wait "+
 				"for the end of the current operation to run your command. Try again in a few moment", environmentName))
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		_, _, err = client.EnvironmentActionsApi.DeployEnvironment(context.Background(), envId).Execute()
@@ -40,6 +44,7 @@ var environmentDeployCmd = &cobra.Command{
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		utils.Println("Environment is deploying!")

--- a/cmd/environment_list.go
+++ b/cmd/environment_list.go
@@ -2,9 +2,10 @@ package cmd
 
 import (
 	"context"
+	"os"
+
 	"github.com/qovery/qovery-cli/utils"
 	"github.com/spf13/cobra"
-	"os"
 )
 
 var environmentListCmd = &cobra.Command{
@@ -17,6 +18,7 @@ var environmentListCmd = &cobra.Command{
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		client := utils.GetQoveryClient(tokenType, token)
@@ -25,6 +27,7 @@ var environmentListCmd = &cobra.Command{
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		environments, _, err := client.EnvironmentsApi.ListEnvironment(context.Background(), projectId).Execute()
@@ -32,6 +35,7 @@ var environmentListCmd = &cobra.Command{
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		statuses, _, err := client.EnvironmentsApi.GetProjectEnvironmentsStatus(context.Background(), projectId).Execute()
@@ -39,6 +43,7 @@ var environmentListCmd = &cobra.Command{
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		var data [][]string
@@ -53,6 +58,7 @@ var environmentListCmd = &cobra.Command{
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 	},
 }

--- a/cmd/environment_redeploy.go
+++ b/cmd/environment_redeploy.go
@@ -3,10 +3,11 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"os"
+
 	"github.com/qovery/qovery-cli/utils"
 	"github.com/qovery/qovery-client-go"
 	"github.com/spf13/cobra"
-	"os"
 )
 
 var environmentRedeployCmd = &cobra.Command{
@@ -19,6 +20,7 @@ var environmentRedeployCmd = &cobra.Command{
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		client := utils.GetQoveryClient(tokenType, token)
@@ -27,12 +29,14 @@ var environmentRedeployCmd = &cobra.Command{
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		if !utils.IsEnvironmentInATerminalState(envId, client) {
 			utils.PrintlnError(fmt.Errorf("environment id '%s' is not in a terminal state. The request is not queued and you must wait "+
 				"for the end of the current operation to run your command. Try again in a few moment", envId))
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		_, _, err = client.EnvironmentActionsApi.RestartEnvironment(context.Background(), envId).Execute()
@@ -40,6 +44,7 @@ var environmentRedeployCmd = &cobra.Command{
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		utils.Println("Environment is redeploying!")

--- a/cmd/environment_stop.go
+++ b/cmd/environment_stop.go
@@ -3,10 +3,11 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"os"
+
 	"github.com/qovery/qovery-cli/utils"
 	"github.com/qovery/qovery-client-go"
 	"github.com/spf13/cobra"
-	"os"
 )
 
 var environmentStopCmd = &cobra.Command{
@@ -19,6 +20,7 @@ var environmentStopCmd = &cobra.Command{
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		client := utils.GetQoveryClient(tokenType, token)
@@ -27,12 +29,14 @@ var environmentStopCmd = &cobra.Command{
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		if !utils.IsEnvironmentInATerminalState(envId, client) {
 			utils.PrintlnError(fmt.Errorf("environment id '%s' is not in a terminal state. The request is not queued and you must wait "+
 				"for the end of the current operation to run your command. Try again in a few moment", envId))
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		_, _, err = client.EnvironmentActionsApi.StopEnvironment(context.Background(), envId).Execute()
@@ -40,6 +44,7 @@ var environmentStopCmd = &cobra.Command{
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		utils.Println("Environment is stopping!")

--- a/cmd/lifecycle_delete.go
+++ b/cmd/lifecycle_delete.go
@@ -3,9 +3,10 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"os"
+
 	"github.com/qovery/qovery-cli/utils"
 	"github.com/spf13/cobra"
-	"os"
 )
 
 var lifecycleDeleteCmd = &cobra.Command{
@@ -18,6 +19,7 @@ var lifecycleDeleteCmd = &cobra.Command{
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		client := utils.GetQoveryClient(tokenType, token)
@@ -26,12 +28,14 @@ var lifecycleDeleteCmd = &cobra.Command{
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		if !utils.IsEnvironmentInATerminalState(envId, client) {
 			utils.PrintlnError(fmt.Errorf("environment id '%s' is not in a terminal state. The request is not queued and you must wait "+
 				"for the end of the current operation to run your command. Try again in a few moment", envId))
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		lifecycles, err := ListLifecycleJobs(envId, client)
@@ -39,6 +43,7 @@ var lifecycleDeleteCmd = &cobra.Command{
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		lifecycle := utils.FindByJobName(lifecycles, lifecycleName)
@@ -47,6 +52,7 @@ var lifecycleDeleteCmd = &cobra.Command{
 			utils.PrintlnError(fmt.Errorf("lifecycle %s not found", lifecycleName))
 			utils.PrintlnInfo("You can list all lifecycle jobs with: qovery lifecycle list")
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		_, err = client.JobMainCallsApi.DeleteJob(context.Background(), lifecycle.Id).Execute()
@@ -54,6 +60,7 @@ var lifecycleDeleteCmd = &cobra.Command{
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		utils.Println("Lifecycle job is deleting!")

--- a/cmd/lifecycle_deploy.go
+++ b/cmd/lifecycle_deploy.go
@@ -3,10 +3,11 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"os"
+
 	"github.com/qovery/qovery-cli/utils"
 	"github.com/qovery/qovery-client-go"
 	"github.com/spf13/cobra"
-	"os"
 )
 
 var lifecycleDeployCmd = &cobra.Command{
@@ -19,6 +20,7 @@ var lifecycleDeployCmd = &cobra.Command{
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		client := utils.GetQoveryClient(tokenType, token)
@@ -27,12 +29,14 @@ var lifecycleDeployCmd = &cobra.Command{
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		if !utils.IsEnvironmentInATerminalState(envId, client) {
 			utils.PrintlnError(fmt.Errorf("environment id '%s' is not in a terminal state. The request is not queued and you must wait "+
 				"for the end of the current operation to run your command. Try again in a few moment", envId))
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		lifecycles, err := ListLifecycleJobs(envId, client)
@@ -40,6 +44,7 @@ var lifecycleDeployCmd = &cobra.Command{
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		lifecycle := utils.FindByJobName(lifecycles, lifecycleName)
@@ -48,6 +53,7 @@ var lifecycleDeployCmd = &cobra.Command{
 			utils.PrintlnError(fmt.Errorf("lifecycle %s not found", lifecycleName))
 			utils.PrintlnInfo("You can list all lifecycle jobs with: qovery lifecycle list")
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		docker := lifecycle.Source.Docker.Get()
@@ -74,6 +80,7 @@ var lifecycleDeployCmd = &cobra.Command{
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		utils.Println("Lifecycle job is deploying!")

--- a/cmd/lifecycle_list.go
+++ b/cmd/lifecycle_list.go
@@ -2,9 +2,10 @@ package cmd
 
 import (
 	"context"
+	"os"
+
 	"github.com/qovery/qovery-cli/utils"
 	"github.com/spf13/cobra"
-	"os"
 )
 
 var lifecycleListCmd = &cobra.Command{
@@ -17,6 +18,7 @@ var lifecycleListCmd = &cobra.Command{
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		client := utils.GetQoveryClient(tokenType, token)
@@ -26,6 +28,7 @@ var lifecycleListCmd = &cobra.Command{
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		lifecycles, err := ListLifecycleJobs(envId, client)
@@ -33,6 +36,7 @@ var lifecycleListCmd = &cobra.Command{
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		statuses, _, err := client.EnvironmentMainCallsApi.GetEnvironmentStatuses(context.Background(), envId).Execute()
@@ -40,6 +44,7 @@ var lifecycleListCmd = &cobra.Command{
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		var data [][]string
@@ -54,6 +59,7 @@ var lifecycleListCmd = &cobra.Command{
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 	},
 }

--- a/cmd/lifecycle_redeploy.go
+++ b/cmd/lifecycle_redeploy.go
@@ -3,9 +3,10 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"os"
+
 	"github.com/qovery/qovery-cli/utils"
 	"github.com/spf13/cobra"
-	"os"
 )
 
 var lifecycleRedeployCmd = &cobra.Command{
@@ -18,6 +19,7 @@ var lifecycleRedeployCmd = &cobra.Command{
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		client := utils.GetQoveryClient(tokenType, token)
@@ -26,12 +28,14 @@ var lifecycleRedeployCmd = &cobra.Command{
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		if !utils.IsEnvironmentInATerminalState(envId, client) {
 			utils.PrintlnError(fmt.Errorf("environment id '%s' is not in a terminal state. The request is not queued and you must wait "+
 				"for the end of the current operation to run your command. Try again in a few moment", envId))
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		lifecycles, err := ListLifecycleJobs(envId, client)
@@ -39,6 +43,7 @@ var lifecycleRedeployCmd = &cobra.Command{
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		lifecycle := utils.FindByJobName(lifecycles, lifecycleName)
@@ -47,6 +52,7 @@ var lifecycleRedeployCmd = &cobra.Command{
 			utils.PrintlnError(fmt.Errorf("lifecycle %s not found", lifecycleName))
 			utils.PrintlnInfo("You can list all lifecycle jobs with: qovery lifecycle list")
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		_, _, err = client.JobActionsApi.RestartJob(context.Background(), lifecycle.Id).Execute()
@@ -54,6 +60,7 @@ var lifecycleRedeployCmd = &cobra.Command{
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		utils.Println("Lifecycle is redeploying!")

--- a/cmd/lifecycle_stop.go
+++ b/cmd/lifecycle_stop.go
@@ -3,9 +3,10 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"os"
+
 	"github.com/qovery/qovery-cli/utils"
 	"github.com/spf13/cobra"
-	"os"
 )
 
 var lifecycleStopCmd = &cobra.Command{
@@ -18,6 +19,7 @@ var lifecycleStopCmd = &cobra.Command{
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		client := utils.GetQoveryClient(tokenType, token)
@@ -26,12 +28,14 @@ var lifecycleStopCmd = &cobra.Command{
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		if !utils.IsEnvironmentInATerminalState(envId, client) {
 			utils.PrintlnError(fmt.Errorf("environment id '%s' is not in a terminal state. The request is not queued and you must wait "+
 				"for the end of the current operation to run your command. Try again in a few moment", envId))
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		lifecycles, err := ListLifecycleJobs(envId, client)
@@ -39,6 +43,7 @@ var lifecycleStopCmd = &cobra.Command{
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		lifecycle := utils.FindByJobName(lifecycles, lifecycleName)
@@ -47,6 +52,7 @@ var lifecycleStopCmd = &cobra.Command{
 			utils.PrintlnError(fmt.Errorf("lifecycle %s not found", lifecycleName))
 			utils.PrintlnInfo("You can list all lifecycle jobs with: qovery lifecycle list")
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		_, _, err = client.JobActionsApi.StopJob(context.Background(), lifecycle.Id).Execute()
@@ -54,6 +60,7 @@ var lifecycleStopCmd = &cobra.Command{
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		utils.Println("Lifecycle job is stopping!")

--- a/cmd/service_list.go
+++ b/cmd/service_list.go
@@ -2,11 +2,12 @@ package cmd
 
 import (
 	"context"
+	"os"
+	"strings"
+
 	"github.com/qovery/qovery-cli/utils"
 	"github.com/qovery/qovery-client-go"
 	"github.com/spf13/cobra"
-	"os"
-	"strings"
 )
 
 var organizationName string
@@ -24,6 +25,7 @@ var serviceListCmd = &cobra.Command{
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		client := utils.GetQoveryClient(tokenType, token)
@@ -32,6 +34,7 @@ var serviceListCmd = &cobra.Command{
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		apps, _, err := client.ApplicationsApi.ListApplication(context.Background(), envId).Execute()
@@ -39,6 +42,7 @@ var serviceListCmd = &cobra.Command{
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		databases, _, err := client.DatabasesApi.ListDatabase(context.Background(), envId).Execute()
@@ -46,6 +50,7 @@ var serviceListCmd = &cobra.Command{
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		containers, _, err := client.ContainersApi.ListContainer(context.Background(), envId).Execute()
@@ -53,6 +58,7 @@ var serviceListCmd = &cobra.Command{
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		jobs, _, err := client.JobsApi.ListJobs(context.Background(), envId).Execute()
@@ -60,6 +66,7 @@ var serviceListCmd = &cobra.Command{
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		statuses, _, err := client.EnvironmentMainCallsApi.GetEnvironmentStatuses(context.Background(), envId).Execute()
@@ -67,6 +74,7 @@ var serviceListCmd = &cobra.Command{
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		var data [][]string
@@ -92,6 +100,7 @@ var serviceListCmd = &cobra.Command{
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 	},
 }

--- a/cmd/shell.go
+++ b/cmd/shell.go
@@ -116,6 +116,7 @@ func shellRequestFromContext(currentContext utils.QoveryContext) (*pkg.ShellRequ
 	if err != nil {
 		utils.PrintlnError(err)
 		os.Exit(1)
+		panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 	}
 
 	client := utils.GetQoveryClient(tokenType, token)

--- a/pkg/vault.go
+++ b/pkg/vault.go
@@ -2,10 +2,11 @@ package pkg
 
 import (
 	b64 "encoding/base64"
+	"os"
+
 	"github.com/hashicorp/vault/api"
 	"github.com/qovery/qovery-cli/utils"
 	log "github.com/sirupsen/logrus"
-	"os"
 )
 
 func connectToVault() *api.Client {
@@ -34,10 +35,12 @@ func GetVarsByClusterId(clusterID string) []utils.Var {
 	if err != nil {
 		log.Error(err)
 		os.Exit(1)
+		panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 	}
 	if result == nil {
 		log.Error("Cluster information are not found")
 		os.Exit(1)
+		panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 	}
 
 	var vaultVars []utils.Var

--- a/utils/command_validator.go
+++ b/utils/command_validator.go
@@ -38,6 +38,7 @@ func getInput(actionType string) string {
 	if err != nil {
 		log.Errorf("Prompt failed %v", err)
 		os.Exit(1)
+		panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 	}
 
 	return result

--- a/utils/file_handler.go
+++ b/utils/file_handler.go
@@ -1,9 +1,10 @@
 package utils
 
 import (
-	log "github.com/sirupsen/logrus"
 	"os"
 	"runtime"
+
+	log "github.com/sirupsen/logrus"
 )
 
 func WriteInFile(clusterId string, fileName string, content []byte) string {
@@ -13,6 +14,7 @@ func WriteInFile(clusterId string, fileName string, content []byte) string {
 		if err != nil {
 			log.Error("Couldn't create folder : " + err.Error())
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 	}
 

--- a/utils/qovery.go
+++ b/utils/qovery.go
@@ -3,11 +3,12 @@ package utils
 import (
 	"errors"
 	"fmt"
-	"github.com/pterm/pterm"
 	"os"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/pterm/pterm"
 
 	"github.com/manifoldco/promptui"
 	"github.com/qovery/qovery-client-go"
@@ -511,6 +512,7 @@ func CheckAdminUrl() {
 	if _, ok := os.LookupEnv("ADMIN_URL"); !ok {
 		log.Error("You must set the Qovery admin root url (ADMIN_URL).")
 		os.Exit(1)
+		panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 	}
 }
 
@@ -823,6 +825,7 @@ func WatchEnvironmentWithOptions(envId string, finalServiceState qovery.StateEnu
 
 		if strings.HasSuffix(string(status.State), "ERROR") {
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		time.Sleep(3 * time.Second)
@@ -844,6 +847,7 @@ out:
 			break out
 		case Err:
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		time.Sleep(3 * time.Second)
@@ -870,6 +874,7 @@ out:
 			break out
 		case Err:
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		time.Sleep(3 * time.Second)
@@ -896,6 +901,7 @@ out:
 			break out
 		case Err:
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		time.Sleep(3 * time.Second)
@@ -922,6 +928,7 @@ out:
 			break out
 		case Err:
 			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		time.Sleep(3 * time.Second)


### PR DESCRIPTION
staticcheck seems to trigger false positives when user os.Exit(), it's
described in their docs as:

Staticcheck tries to deduce which functions abort control flow. For
example, it is aware that a function will not continue execution after a
call to panic or log.Fatal. However, sometimes this detection fails, in
particular in the presence of conditionals. Consider the following
example:

```
func Log(msg string, level int) {
        fmt.Println(msg)
            if level == levelFatal {
                        os.Exit(1)

            }

}

func Fatal(msg string) {
        Log(msg, levelFatal)

}

func fn(x *int) {
    if x == nil {
                Fatal("unexpected nil pointer")

    }
        fmt.Println(*x)

}
```

Staticcheck will flag the dereference of x, even though it is perfectly
safe. Staticcheck is not able to deduce that a call to Fatal will exit
the program. For the time being, the easiest workaround is to modify the
definition of Fatal like so:

```
func Fatal(msg string) {
        Log(msg, levelFatal)
            panic("unreachable")

}
```

Full doc: https://staticcheck.io/docs/checks#SA5011
