### PR TITLE
fix: pass autodeploy param to services update

### DIFF
--- a/cmd/application_update.go
+++ b/cmd/application_update.go
@@ -81,6 +81,7 @@ var applicationUpdateCmd = &cobra.Command{
 			Ports:               application.Ports,
 			Arguments:           application.Arguments,
 			Entrypoint:          application.Entrypoint,
+			AutoDeploy:          *qovery.NewNullableBool(application.AutoDeploy),
 		}
 
 		if applicationBranch != "" {

--- a/cmd/container_update.go
+++ b/cmd/container_update.go
@@ -99,6 +99,7 @@ var containerUpdateCmd = &cobra.Command{
 			MaxRunningInstances: utils.Int32(container.MaxRunningInstances),
 			Healthchecks:        container.Healthchecks,
 			AutoPreview:         utils.Bool(container.AutoPreview),
+			AutoDeploy:          *qovery.NewNullableBool(container.AutoDeploy),
 		}
 
 		_, res, err := client.ContainerMainCallsAPI.EditContainer(context.Background(), container.Id).ContainerRequest(req).Execute()

--- a/cmd/lifecycle_update.go
+++ b/cmd/lifecycle_update.go
@@ -65,7 +65,7 @@ var lifecycleUpdateCmd = &cobra.Command{
 		}
 
 		docker := lifecycle.Source.JobResponseAllOfSourceOneOf1.Docker
-	image := lifecycle.Source.JobResponseAllOfSourceOneOf.Image
+		image := lifecycle.Source.JobResponseAllOfSourceOneOf.Image
 
 		if docker != nil && (lifecycleTag != "" || lifecycleImageName != "") {
 			utils.PrintlnError(fmt.Errorf("you can't use --tag or --image-name with a lifecycle targetting a Dockerfile. Use --branch instead"))

--- a/utils/qovery.go
+++ b/utils/qovery.go
@@ -2108,6 +2108,7 @@ func ToJobRequest(job qovery.JobResponse) qovery.JobRequest {
 		Source:             &source,
 		Healthchecks:       job.Healthchecks,
 		Schedule:           &schedule,
+		AutoDeploy:         *qovery.NewNullableBool(job.AutoDeploy),
 	}
 }
 


### PR DESCRIPTION
CLI service update didn't pass `AutoDeploy` param to qovery backend which fallbacks to `true` by default.

Ticket: ENG-1618
