### PR TITLE
Bug Fix: Cannot Update Cronjobs/Consuming CronJobResponse when LifecycleJobResponse is nil

### DIFF
--- a/utils/qovery.go
+++ b/utils/qovery.go
@@ -2501,18 +2501,18 @@ func ToJobRequest(job qovery.JobResponse) qovery.JobRequest {
 		}
 
 		return qovery.JobRequest{
-			Name:               job.LifecycleJobResponse.Name,
-			Description:        job.LifecycleJobResponse.Description,
-			Cpu:                Int32(job.LifecycleJobResponse.Cpu),
-			Memory:             Int32(job.LifecycleJobResponse.Memory),
-			MaxNbRestart:       job.LifecycleJobResponse.MaxNbRestart,
-			MaxDurationSeconds: job.LifecycleJobResponse.MaxDurationSeconds,
-			AutoPreview:        Bool(job.LifecycleJobResponse.AutoPreview),
-			Port:               job.LifecycleJobResponse.Port,
+			Name:               job.CronJobResponse.Name,
+			Description:        job.CronJobResponse.Description,
+			Cpu:                Int32(job.CronJobResponse.Cpu),
+			Memory:             Int32(job.CronJobResponse.Memory),
+			MaxNbRestart:       job.CronJobResponse.MaxNbRestart,
+			MaxDurationSeconds: job.CronJobResponse.MaxDurationSeconds,
+			AutoPreview:        Bool(job.CronJobResponse.AutoPreview),
+			Port:               job.CronJobResponse.Port,
 			Source:             &source,
-			Healthchecks:       job.LifecycleJobResponse.Healthchecks,
+			Healthchecks:       job.CronJobResponse.Healthchecks,
 			Schedule:           &schedule,
-			AutoDeploy:         *qovery.NewNullableBool(job.LifecycleJobResponse.AutoDeploy),
+			AutoDeploy:         *qovery.NewNullableBool(job.CronJobResponse.AutoDeploy),
 		}
 	}
 }


### PR DESCRIPTION
Hi Team!

Ran into this bug this morning, it looks like the CronJob update logic had been updated last week && in that update, it runs a check for job.LifecycleJobResponse != nil, but then references the  job.LifecycleJobResponse in the "else" section. I *think* this is a typo & should be swapped to job.CronJobResponse. I've tested this locally & it has fixed the bug on my end.

The job.LifecycleJobResponse nil check: https://github.com/Qovery/qovery-cli/blob/main/utils/qovery.go#L2467

The current CLI output (the bug): 
```
qovery cronjob update --organization <org> --project <project> --environment <env> --tag <tag> -n <cronjobname> --image-name <image name>
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x60 pc=0x1048e8b48]

goroutine 1 [running]:
github.com/qovery/qovery-cli/utils.ToJobRequest({0x1400038e0e0, 0x0})
	/home/runner/work/qovery-cli/qovery-cli/utils/qovery.go:2506 +0x4b8
github.com/qovery/qovery-cli/cmd.glob..func85(0x14000234000?, {0x104ac844d?, 0x4?, 0x104ac8451?})
	/home/runner/work/qovery-cli/qovery-cli/cmd/cronjob_update.go:90 +0x200
github.com/spf13/cobra.(*Command).execute(0x10533a9a0, {0x1400017a3c0, 0xc, 0xc})
	/home/runner/go/pkg/mod/github.com/spf13/cobra@v1.6.1/command.go:920 +0x654
github.com/spf13/cobra.(*Command).ExecuteC(0x105335c00)
	/home/runner/go/pkg/mod/github.com/spf13/cobra@v1.6.1/command.go:1044 +0x320
github.com/spf13/cobra.(*Command).Execute(...)
	/home/runner/go/pkg/mod/github.com/spf13/cobra@v1.6.1/command.go:968
github.com/qovery/qovery-cli/cmd.Execute()
	/home/runner/work/qovery-cli/qovery-cli/cmd/root.go:19 +0x24
main.main()
	/home/runner/work/qovery-cli/qovery-cli/main.go:6 +0x1c
```

The CLI output after the PR change:
```
go run ./main.go cronjob update --organization <org> --project <project> --environment <env> --tag <tag> -n <cronjobname> --image-name <image name>
Cronjob <cronjobname> updated!
```

Please let me know if there I can update this PR with any additional info or formatting so it is in the right state for a merge :)

Thank you!