### PR TITLE
 feat: Add Update Environment Variable support

### DIFF
--- a/cmd/application_env_update.go
+++ b/cmd/application_env_update.go
@@ -1,0 +1,76 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/pterm/pterm"
+	"github.com/qovery/qovery-cli/utils"
+	"github.com/spf13/cobra"
+)
+
+var applicationEnvUpdateCmd = &cobra.Command{
+	Use:   "update",
+	Short: "Update application environment variable or secret",
+	Run: func(cmd *cobra.Command, args []string) {
+		utils.Capture(cmd)
+
+		tokenType, token, err := utils.GetAccessToken()
+		if err != nil {
+			utils.PrintlnError(err)
+			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
+		}
+
+		client := utils.GetQoveryClient(tokenType, token)
+		_, _, envId, err := getOrganizationProjectEnvironmentContextResourcesIds(client)
+
+		if err != nil {
+			utils.PrintlnError(err)
+			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
+		}
+
+		applications, _, err := client.ApplicationsAPI.ListApplication(context.Background(), envId).Execute()
+
+		if err != nil {
+			utils.PrintlnError(err)
+			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
+		}
+
+		application := utils.FindByApplicationName(applications.GetResults(), applicationName)
+
+		if application == nil {
+			utils.PrintlnError(fmt.Errorf("application %s not found", applicationName))
+			utils.PrintlnInfo("You can list all applications with: qovery application list")
+			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
+		}
+
+		err = utils.UpdateEnvironmentVariable(client, utils.Key, utils.Value, application.Id, utils.ApplicationType)
+
+		if err != nil {
+			utils.PrintlnError(err)
+			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
+		}
+
+		utils.Println(fmt.Sprintf("Environment variable %s has been updated", pterm.FgBlue.Sprintf(utils.Key)))
+	},
+}
+
+func init() {
+	applicationEnvCmd.AddCommand(applicationEnvUpdateCmd)
+	applicationEnvUpdateCmd.Flags().StringVarP(&organizationName, "organization", "", "", "Organization Name")
+	applicationEnvUpdateCmd.Flags().StringVarP(&projectName, "project", "", "", "Project Name")
+	applicationEnvUpdateCmd.Flags().StringVarP(&environmentName, "environment", "", "", "Environment Name")
+	applicationEnvUpdateCmd.Flags().StringVarP(&applicationName, "application", "n", "", "Application Name")
+	applicationEnvUpdateCmd.Flags().StringVarP(&utils.Key, "key", "k", "", "Environment variable or secret key")
+	applicationEnvUpdateCmd.Flags().StringVarP(&utils.Value, "value", "v", "", "Environment variable or secret value")
+
+	_ = applicationEnvUpdateCmd.MarkFlagRequired("key")
+	_ = applicationEnvUpdateCmd.MarkFlagRequired("value")
+	_ = applicationEnvUpdateCmd.MarkFlagRequired("application")
+}

--- a/cmd/container_env_update.go
+++ b/cmd/container_env_update.go
@@ -1,0 +1,75 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/pterm/pterm"
+	"github.com/qovery/qovery-cli/utils"
+	"github.com/spf13/cobra"
+)
+
+var containerEnvUpdateCmd = &cobra.Command{
+	Use:   "update",
+	Short: "Update container environment variable or secret",
+	Run: func(cmd *cobra.Command, args []string) {
+		utils.Capture(cmd)
+
+		tokenType, token, err := utils.GetAccessToken()
+		if err != nil {
+			utils.PrintlnError(err)
+			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
+		}
+
+		client := utils.GetQoveryClient(tokenType, token)
+		_, _, envId, err := getOrganizationProjectEnvironmentContextResourcesIds(client)
+
+		if err != nil {
+			utils.PrintlnError(err)
+			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
+		}
+
+		containers, _, err := client.ContainersAPI.ListContainer(context.Background(), envId).Execute()
+
+		if err != nil {
+			utils.PrintlnError(err)
+			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
+		}
+
+		container := utils.FindByContainerName(containers.GetResults(), containerName)
+
+		if container == nil {
+			utils.PrintlnError(fmt.Errorf("container %s not found", containerName))
+			utils.PrintlnInfo("You can list all containers with: qovery container list")
+			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
+		}
+
+		err = utils.UpdateEnvironmentVariable(client, utils.Key, utils.Value, container.Id, utils.ContainerType)
+
+		if err != nil {
+			utils.PrintlnError(err)
+			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
+		}
+
+		utils.Println(fmt.Sprintf("Environment variable %s has been updated", pterm.FgBlue.Sprintf(utils.Key)))
+	},
+}
+
+func init() {
+	containerEnvCmd.AddCommand(containerEnvUpdateCmd)
+	containerEnvUpdateCmd.Flags().StringVarP(&organizationName, "organization", "", "", "Organization Name")
+	containerEnvUpdateCmd.Flags().StringVarP(&projectName, "project", "", "", "Project Name")
+	containerEnvUpdateCmd.Flags().StringVarP(&environmentName, "environment", "", "", "Environment Name")
+	containerEnvUpdateCmd.Flags().StringVarP(&containerName, "container", "n", "", "Container Name")
+	containerEnvUpdateCmd.Flags().StringVarP(&utils.Key, "key", "k", "", "Environment variable or secret key")
+	containerEnvUpdateCmd.Flags().StringVarP(&utils.Value, "value", "v", "", "Environment variable or secret value")
+	_ = containerEnvUpdateCmd.MarkFlagRequired("key")
+	_ = containerEnvUpdateCmd.MarkFlagRequired("value")
+	_ = containerEnvUpdateCmd.MarkFlagRequired("container")
+}

--- a/cmd/cronjob_env_update.go
+++ b/cmd/cronjob_env_update.go
@@ -1,0 +1,75 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/pterm/pterm"
+	"github.com/qovery/qovery-cli/utils"
+	"github.com/spf13/cobra"
+)
+
+var cronjobEnvUpdateCmd = &cobra.Command{
+	Use:   "update",
+	Short: "Update cronjob environment variable or secret",
+	Run: func(cmd *cobra.Command, args []string) {
+		utils.Capture(cmd)
+
+		tokenType, token, err := utils.GetAccessToken()
+		if err != nil {
+			utils.PrintlnError(err)
+			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
+		}
+
+		client := utils.GetQoveryClient(tokenType, token)
+		_, _, envId, err := getOrganizationProjectEnvironmentContextResourcesIds(client)
+
+		if err != nil {
+			utils.PrintlnError(err)
+			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
+		}
+
+		cronjobs, _, err := client.JobsAPI.ListJobs(context.Background(), envId).Execute()
+
+		if err != nil {
+			utils.PrintlnError(err)
+			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
+		}
+
+		cronjob := utils.FindByJobName(cronjobs.GetResults(), cronjobName)
+
+		if cronjob == nil || cronjob.CronJobResponse == nil {
+			utils.PrintlnError(fmt.Errorf("cronjob %s not found", cronjobName))
+			utils.PrintlnInfo("You can list all cronjobs with: qovery cronjob list")
+			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
+		}
+
+		err = utils.UpdateEnvironmentVariable(client, utils.Key, utils.Value, cronjob.CronJobResponse.Id, utils.JobType)
+
+		if err != nil {
+			utils.PrintlnError(err)
+			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
+		}
+
+		utils.Println(fmt.Sprintf("Environment variable %s has been updated", pterm.FgBlue.Sprintf(utils.Key)))
+	},
+}
+
+func init() {
+	cronjobEnvCmd.AddCommand(cronjobEnvUpdateCmd)
+	cronjobEnvUpdateCmd.Flags().StringVarP(&organizationName, "organization", "", "", "Organization Name")
+	cronjobEnvUpdateCmd.Flags().StringVarP(&projectName, "project", "", "", "Project Name")
+	cronjobEnvUpdateCmd.Flags().StringVarP(&environmentName, "environment", "", "", "Environment Name")
+	cronjobEnvUpdateCmd.Flags().StringVarP(&cronjobName, "cronjob", "n", "", "Cronjob Name")
+	cronjobEnvUpdateCmd.Flags().StringVarP(&utils.Key, "key", "k", "", "Environment variable or secret key")
+	cronjobEnvUpdateCmd.Flags().StringVarP(&utils.Value, "value", "v", "", "Environment variable or secret value")
+	_ = cronjobEnvUpdateCmd.MarkFlagRequired("key")
+	_ = cronjobEnvUpdateCmd.MarkFlagRequired("value")
+	_ = cronjobEnvUpdateCmd.MarkFlagRequired("cronjob")
+}

--- a/cmd/helm_env_update.go
+++ b/cmd/helm_env_update.go
@@ -1,0 +1,76 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/pterm/pterm"
+	"github.com/qovery/qovery-cli/utils"
+	"github.com/spf13/cobra"
+)
+
+var helmEnvUpdateCmd = &cobra.Command{
+	Use:   "update",
+	Short: "Update helm environment variable or secret",
+	Run: func(cmd *cobra.Command, args []string) {
+		utils.Capture(cmd)
+
+		tokenType, token, err := utils.GetAccessToken()
+		if err != nil {
+			utils.PrintlnError(err)
+			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
+		}
+
+		client := utils.GetQoveryClient(tokenType, token)
+		_, _, envId, err := getOrganizationProjectEnvironmentContextResourcesIds(client)
+
+		if err != nil {
+			utils.PrintlnError(err)
+			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
+		}
+
+		helms, _, err := client.HelmsAPI.ListHelms(context.Background(), envId).Execute()
+
+		if err != nil {
+			utils.PrintlnError(err)
+			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
+		}
+
+		helm := utils.FindByHelmName(helms.GetResults(), helmName)
+
+		if helm == nil {
+			utils.PrintlnError(fmt.Errorf("helm %s not found", helmName))
+			utils.PrintlnInfo("You can list all helms with: qovery helm list")
+			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
+		}
+
+		err = utils.UpdateEnvironmentVariable(client, utils.Key, utils.Value, helm.Id, utils.HelmType)
+
+		if err != nil {
+			utils.PrintlnError(err)
+			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
+		}
+
+		utils.Println(fmt.Sprintf("Environment variable %s has been updated", pterm.FgBlue.Sprintf(utils.Key)))
+	},
+}
+
+func init() {
+	helmEnvCmd.AddCommand(helmEnvUpdateCmd)
+	helmEnvUpdateCmd.Flags().StringVarP(&organizationName, "organization", "", "", "Organization Name")
+	helmEnvUpdateCmd.Flags().StringVarP(&projectName, "project", "", "", "Project Name")
+	helmEnvUpdateCmd.Flags().StringVarP(&environmentName, "environment", "", "", "Environment Name")
+	helmEnvUpdateCmd.Flags().StringVarP(&helmName, "helm", "n", "", "helm Name")
+	helmEnvUpdateCmd.Flags().StringVarP(&utils.Key, "key", "k", "", "Environment variable or secret key")
+	helmEnvUpdateCmd.Flags().StringVarP(&utils.Value, "value", "v", "", "Environment variable or secret value")
+
+	_ = helmEnvUpdateCmd.MarkFlagRequired("key")
+	_ = helmEnvUpdateCmd.MarkFlagRequired("value")
+	_ = helmEnvUpdateCmd.MarkFlagRequired("helm")
+}

--- a/cmd/lifecycle_env_update.go
+++ b/cmd/lifecycle_env_update.go
@@ -1,0 +1,75 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/pterm/pterm"
+	"github.com/qovery/qovery-cli/utils"
+	"github.com/spf13/cobra"
+)
+
+var lifecycleEnvUpdateCmd = &cobra.Command{
+	Use:   "update",
+	Short: "Update lifecycle environment variable or secret",
+	Run: func(cmd *cobra.Command, args []string) {
+		utils.Capture(cmd)
+
+		tokenType, token, err := utils.GetAccessToken()
+		if err != nil {
+			utils.PrintlnError(err)
+			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
+		}
+
+		client := utils.GetQoveryClient(tokenType, token)
+		_, _, envId, err := getOrganizationProjectEnvironmentContextResourcesIds(client)
+
+		if err != nil {
+			utils.PrintlnError(err)
+			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
+		}
+
+		lifecycles, _, err := client.JobsAPI.ListJobs(context.Background(), envId).Execute()
+
+		if err != nil {
+			utils.PrintlnError(err)
+			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
+		}
+
+		lifecycle := utils.FindByJobName(lifecycles.GetResults(), lifecycleName)
+
+		if lifecycle == nil || lifecycle.LifecycleJobResponse == nil {
+			utils.PrintlnError(fmt.Errorf("lifecycle %s not found", lifecycleName))
+			utils.PrintlnInfo("You can list all lifecycles with: qovery lifecycle list")
+			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
+		}
+
+		err = utils.UpdateEnvironmentVariable(client, utils.Key, utils.Value, lifecycle.LifecycleJobResponse.Id, utils.JobType)
+
+		if err != nil {
+			utils.PrintlnError(err)
+			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
+		}
+
+		utils.Println(fmt.Sprintf("Environment variable %s has been updated", pterm.FgBlue.Sprintf(utils.Key)))
+	},
+}
+
+func init() {
+	lifecycleEnvCmd.AddCommand(lifecycleEnvUpdateCmd)
+	lifecycleEnvUpdateCmd.Flags().StringVarP(&organizationName, "organization", "", "", "Organization Name")
+	lifecycleEnvUpdateCmd.Flags().StringVarP(&projectName, "project", "", "", "Project Name")
+	lifecycleEnvUpdateCmd.Flags().StringVarP(&environmentName, "environment", "", "", "Environment Name")
+	lifecycleEnvUpdateCmd.Flags().StringVarP(&lifecycleName, "lifecycle", "n", "", "Lifecycle Name")
+	lifecycleEnvUpdateCmd.Flags().StringVarP(&utils.Key, "key", "k", "", "Environment variable or secret key")
+	lifecycleEnvUpdateCmd.Flags().StringVarP(&utils.Value, "value", "v", "", "Environment variable or secret value")
+	_ = lifecycleEnvUpdateCmd.MarkFlagRequired("key")
+	_ = lifecycleEnvUpdateCmd.MarkFlagRequired("value")
+	_ = lifecycleEnvUpdateCmd.MarkFlagRequired("lifecycle")
+}

--- a/utils/env_var.go
+++ b/utils/env_var.go
@@ -182,6 +182,34 @@ func CreateEnvironmentVariable(
 	return err
 }
 
+func UpdateEnvironmentVariable(
+	client *qovery.APIClient,
+	key string,
+	value string,
+	serviceId string,
+	serviceType ServiceType,
+) error {
+	envVars, err := ListEnvironmentVariables(client, serviceId, serviceType)
+	if err != nil {
+		return err
+	}
+
+	envVar := FindEnvironmentVariableByKey(key, envVars)
+	if envVar == nil {
+		return fmt.Errorf("environment variable %s not found", pterm.FgRed.Sprintf(key))
+	}
+
+    // fmt.Printf(envVar.Id)
+	variableId := envVar.Id
+	variableEditRequest := qovery.VariableEditRequest{
+		Key:       key,
+		Value:     value,
+	}
+
+	_, _, err = client.VariableMainCallsAPI.EditVariable(context.Background(), variableId).VariableEditRequest(variableEditRequest).Execute()
+	return err
+}
+
 func FindEnvironmentVariableByKey(key string, envVars []qovery.VariableResponse) *qovery.VariableResponse {
 	for _, envVar := range envVars {
 		if envVar.Key == key {
@@ -248,12 +276,7 @@ func getParentIdByScope(scope string, projectId string, environmentId string, se
 	return "", qovery.APIVARIABLESCOPEENUM_BUILT_IN, fmt.Errorf("scope %s not supported", scope)
 }
 
-func DeleteVariable(
-	client *qovery.APIClient,
-	serviceId string,
-	serviceType ServiceType,
-	key string,
-) error {
+func DeleteVariable(client *qovery.APIClient, serviceId string, serviceType ServiceType, key string) error {
 
 	envVars, err := ListEnvironmentVariables(client, serviceId, serviceType)
 	if err != nil {


### PR DESCRIPTION
This PR adds support for updating Environment variables in lifecycle, application, container, helm and cronjob.

the commands will be as follows:

```
qovery lifecycle env update --organization test--project test --environment test --lifecycle test --key BRANCH_NAME --value test-pr
```