### PR TITLE
fix: Use correct filter when forcing DEPLOYED clusters on deploy

### DIFF
--- a/cmd/admin_cluster_deploy.go
+++ b/cmd/admin_cluster_deploy.go
@@ -38,8 +38,8 @@ func init() {
 func deployClusters() {
 	utils.CheckAdminUrl()
 
-	// if no filters is set, enforce to select only RUNNING clusters to avoid mistakes (e.g deploying a stopped cluster)
-	_, containsKey := filters["ClusterStatus"]
+	// if no filter is set, enforce to select only RUNNING clusters to avoid mistakes (e.g deploying a stopped cluster)
+	_, containsKey := filters["CurrentStatus"]
 	if !containsKey {
 		filters["CurrentStatus"] = "DEPLOYED"
 	}

--- a/pkg/version.go
+++ b/pkg/version.go
@@ -11,7 +11,7 @@ import (
 )
 
 func GetCurrentVersion() string {
-	return "0.84.0" // ci-version-check
+	return "0.84.1" // ci-version-check
 }
 
 func GetLatestOnlineVersionUrl() (string, error) {


### PR DESCRIPTION
To avoid mistakes, force the cluster statuses to be DEPLOYED if no status is used in the filters