### PR TITLE
Disable sentry

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,13 +1,13 @@
 package cmd
 
 import (
-	"github.com/getsentry/sentry-go"
-	"github.com/qovery/qovery-cli/pkg"
+//	"github.com/getsentry/sentry-go"
+//	"github.com/qovery/qovery-cli/pkg"
 	"github.com/qovery/qovery-cli/utils"
 	"github.com/qovery/qovery-cli/variable"
 	"github.com/spf13/cobra"
 	"os"
-	"time"
+//	"time"
 )
 
 var rootCmd = &cobra.Command{
@@ -35,44 +35,44 @@ func initConfig() {
 			os.Exit(0)
 		}
 	}
-	initSentry()
+	//initSentry()
 }
 
-func initSentry() {
-	pkg.GetCurrentVersion()
-	err := sentry.Init(sentry.ClientOptions{
-		Dsn:         "https://199e1e8385d94377a98676dadcd77e2d@o471935.ingest.sentry.io/5866472",
-		Environment: "prod",
-		Release:     pkg.GetCurrentVersion(),
-		// Enable printing of SDK debug messages.
-		// Useful when getting started or trying to figure something out.
-		Debug: false,
-		BeforeSend: func(event *sentry.Event, hint *sentry.EventHint) *sentry.Event {
-			// should not happen by design
-			if event == nil {
-				return event
-			}
-			if event.Exception == nil {
-				return event
-			}
-			if len(event.Exception) > 0 && (event.Exception[0].Stacktrace == nil || event.Exception[0].Stacktrace.Frames == nil) {
-				return event
-			}
-			if len(event.Exception[0].Stacktrace.Frames) > 0 {
-				frames := event.Exception[0].Stacktrace.Frames
-				event.Exception[0].Stacktrace.Frames = frames[:len(frames)-1]
-				frames = event.Exception[0].Stacktrace.Frames
-				path := frames[len(frames)-1].AbsPath
-				event.Transaction = path
-			}
-			return event
-		},
-	})
-	if err != nil {
-		utils.PrintlnError(err)
-	}
-	// Flush buffered events before the program terminates.
-	// Set the timeout to the maximum duration the program can afford to wait.
-	defer sentry.Recover()
-	defer sentry.Flush(5 * time.Second)
-}
+//func initSentry() {
+//	pkg.GetCurrentVersion()
+//	err := sentry.Init(sentry.ClientOptions{
+//		Dsn:         "https://199e1e8385d94377a98676dadcd77e2d@o471935.ingest.sentry.io/5866472",
+//		Environment: "prod",
+//		Release:     pkg.GetCurrentVersion(),
+//		// Enable printing of SDK debug messages.
+//		// Useful when getting started or trying to figure something out.
+//		Debug: false,
+//		BeforeSend: func(event *sentry.Event, hint *sentry.EventHint) *sentry.Event {
+//			// should not happen by design
+//			if event == nil {
+//				return event
+//			}
+//			if event.Exception == nil {
+//				return event
+//			}
+//			if len(event.Exception) > 0 && (event.Exception[0].Stacktrace == nil || event.Exception[0].Stacktrace.Frames == nil) {
+//				return event
+//			}
+//			if len(event.Exception[0].Stacktrace.Frames) > 0 {
+//				frames := event.Exception[0].Stacktrace.Frames
+//				event.Exception[0].Stacktrace.Frames = frames[:len(frames)-1]
+//				frames = event.Exception[0].Stacktrace.Frames
+//				path := frames[len(frames)-1].AbsPath
+//				event.Transaction = path
+//			}
+//			return event
+//		},
+//	})
+//	if err != nil {
+//		utils.PrintlnError(err)
+//	}
+//	// Flush buffered events before the program terminates.
+//	// Set the timeout to the maximum duration the program can afford to wait.
+//	defer sentry.Recover()
+//	defer sentry.Flush(5 * time.Second)
+//}

--- a/utils/printer.go
+++ b/utils/printer.go
@@ -3,18 +3,18 @@ package utils
 import (
 	"fmt"
 	"github.com/fatih/color"
-	"github.com/getsentry/sentry-go"
+//	"github.com/getsentry/sentry-go"
 	"github.com/pterm/pterm"
 	log "github.com/sirupsen/logrus"
-	"time"
+//	"time"
 )
 
 func PrintlnError(err error) {
-	localHub := sentry.CurrentHub().Clone()
-	localHub.Scope().SetTransaction(err.Error())
-	localHub.CaptureException(err)
+	//localHub := sentry.CurrentHub().Clone()
+	//localHub.Scope().SetTransaction(err.Error())
+	//localHub.CaptureException(err)
 	fmt.Printf("%s: %v\n", color.RedString("Error"), err)
-	defer localHub.Flush(5 * time.Second)
+	//defer localHub.Flush(5 * time.Second)
 }
 
 func PrintlnInfo(info string) {


### PR DESCRIPTION
It reports too many irrelevant issues (401, 404) and we dont look at it. To avoid maxing out our quota