### PR TITLE
fix(COR-942): install cluster command

### DIFF
--- a/cmd/cluster_install.go
+++ b/cmd/cluster_install.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"github.com/fatih/color"
 	"github.com/manifoldco/promptui"
@@ -529,13 +530,18 @@ func configureStorageClass(client *qovery.APIClient, cluster *qovery.Cluster) {
 		return
 	}
 
-	utils.Println("We need to know the storage class name that your kubernetes cluster uses to deploy app with network storage.")
-	storageClassUI := promptui.Select{
-		Label: "Storage class name",
-	}
-	_, storageClassName, err := storageClassUI.Run()
+	storageClassName, err := func() *promptui.Prompt {
+		return &promptui.Prompt{
+			Label:   "We need to know the storage class name that your kubernetes cluster uses to deploy app with network storage. Enter your storage class name",
+			Default: "",
+		}
+	}().Run()
 	if err != nil {
 		utils.PrintlnError(err)
+		os.Exit(1)
+	}
+	if storageClassName == "" {
+		utils.PrintlnError(errors.New("storage class name should be defined and cannot be empty"))
 		os.Exit(1)
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/posthog/posthog-go v0.0.0-20240327112532-87b23fe11103
 	github.com/pterm/pterm v0.12.79
-	github.com/qovery/qovery-client-go v0.0.0-20240611152527-5b39ca9f2845
+	github.com/qovery/qovery-client-go v0.0.0-20240618145737-8fd8c6389642
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -210,6 +210,10 @@ github.com/qovery/qovery-client-go v0.0.0-20240611144622-37e60e46633c h1:KMmrB9w
 github.com/qovery/qovery-client-go v0.0.0-20240611144622-37e60e46633c/go.mod h1:9eHj5a4EtXGIyfbvVL3HVYW9k7Xmiwi00OqHrP4dc10=
 github.com/qovery/qovery-client-go v0.0.0-20240611152527-5b39ca9f2845 h1:x7cDoxl+y9Wba9aumkGek3mIn7byyAk3QRrqhzsQ3pw=
 github.com/qovery/qovery-client-go v0.0.0-20240611152527-5b39ca9f2845/go.mod h1:9eHj5a4EtXGIyfbvVL3HVYW9k7Xmiwi00OqHrP4dc10=
+github.com/qovery/qovery-client-go v0.0.0-20240618074642-7e36bc34d583 h1:t8BgK5wk5EB9sTyM4+5RsUsVwu3rws33Im5joOiAwRw=
+github.com/qovery/qovery-client-go v0.0.0-20240618074642-7e36bc34d583/go.mod h1:9eHj5a4EtXGIyfbvVL3HVYW9k7Xmiwi00OqHrP4dc10=
+github.com/qovery/qovery-client-go v0.0.0-20240618145737-8fd8c6389642 h1:zXFbs1KZLdqRA26C3pynPSzj75KAhCNF2BvpwlZL8l4=
+github.com/qovery/qovery-client-go v0.0.0-20240618145737-8fd8c6389642/go.mod h1:9eHj5a4EtXGIyfbvVL3HVYW9k7Xmiwi00OqHrP4dc10=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.4.4 h1:8TfxU8dW6PdqD27gjM8MVNuicgxIjxpm4K7x4jp8sis=
 github.com/rivo/uniseg v0.4.4/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=


### PR DESCRIPTION
This PR includes two patches fixing the cluster install command:

1- Open API spec declaration was wrong, ContainerRegistryMirroringMode
should not be uppercase: fixed by bumping the Qovery SDK lib

2- Prompt was asking for a select for strorage class whereas it should
be a simple string

Ticket: COR-942
