### PR TITLE
fix: Update application update command to pass git token from the application

### DIFF
--- a/cmd/application_update.go
+++ b/cmd/application_update.go
@@ -65,9 +65,10 @@ var applicationUpdateCmd = &cobra.Command{
 			Name:        &application.Name,
 			Description: application.Description,
 			GitRepository: &qovery.ApplicationGitRepositoryRequest{
-				Url:      application.GitRepository.Url,
-				Branch:   application.GitRepository.Branch,
-				RootPath: application.GitRepository.RootPath,
+				Branch:     application.GitRepository.Branch,
+				GitTokenId: application.GitRepository.GitTokenId,
+				RootPath:   application.GitRepository.RootPath,
+				Url:        application.GitRepository.Url,
 			},
 			BuildMode:           application.BuildMode,
 			DockerfilePath:      application.DockerfilePath,

--- a/utils/qovery.go
+++ b/utils/qovery.go
@@ -2510,9 +2510,10 @@ func ToJobRequest(job qovery.JobResponse) qovery.JobRequest {
 
 	if docker != nil {
 		sourceDockerGitRepository := qovery.ApplicationGitRepositoryRequest{
-			Url:      docker.GitRepository.Url,
-			Branch:   docker.GitRepository.Branch,
-			RootPath: docker.GitRepository.RootPath,
+			Branch:     docker.GitRepository.Branch,
+			GitTokenId: docker.GitRepository.GitTokenId,
+			RootPath:   docker.GitRepository.RootPath,
+			Url:        docker.GitRepository.Url,
 		}
 
 		sourceDocker = qovery.JobRequestAllOfSourceDocker{


### PR DESCRIPTION
I've posted a bug about this [on the forum](https://discuss.qovery.com/t/bug-errors-when-updating-an-application-with-the-cli/2785), so there are complete details there. The problem is that updating an application with the CLI doesn't work, at least in my situation, because it's not passing back the git token id that it got when querying the application data. The error it gets is:

```
{"type":"about:blank","title":"Bad Request","status":400,"detail":"You don't have any provider configured for GITHUB","instance":"/api/application/52d4d791-80ba-4d9d-8a6c-2dabe917b62d","message":"You don't have any provider configured for GITHUB"}
```

This changes it to pass the token id. I have confirmed that it works for updating my application.