### PR TITLE
Add flag --services for qovery environment deploy command

### DIFF
--- a/cmd/service_list.go
+++ b/cmd/service_list.go
@@ -21,6 +21,7 @@ var watchFlag bool
 var markdownFlag bool
 var jiraFlag bool
 var jsonFlag bool
+var servicesJson string
 
 var serviceListCmd = &cobra.Command{
 	Use:   "list",

--- a/pkg/version.go
+++ b/pkg/version.go
@@ -11,7 +11,7 @@ import (
 )
 
 func GetCurrentVersion() string {
-	return "0.98.0" // ci-version-check
+	return "0.99.0" // ci-version-check
 }
 
 func GetLatestOnlineVersionUrl() (string, error) {


### PR DESCRIPTION
Everything is in the title right? :) The `--services` flag gives the ability to deploy multiple services from different types in one command. E.g.

```
qovery environment deploy --services '{"applications": [{"app
lication_id": "c1df3b7c-e51b-45f4-bc6f-806aa3c17b00", "git_commit_id": "ad933d741d86205dfd3291d5685060167b85
f910"}, {"application_id": "b4d843d3-9682-4dd8-88bb-0c11a47446e8", "git_commit_id": "3780712b525138881ac40f3
d38071bf29e8f8d4f"}]}'
```

The payload must be in JSON format (cf. https://api-doc.qovery.com/#tag/Environment-Actions/operation/deployAllServices)