### PR TITLE
feat: add QOVERY_TELEMETRY env var to avoid sending events to Qovery telemetry system

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -3,10 +3,11 @@ package cmd
 import (
 	//	"github.com/getsentry/sentry-go"
 	//	"github.com/qovery/qovery-cli/pkg"
+	"os"
+
 	"github.com/qovery/qovery-cli/utils"
 	"github.com/qovery/qovery-cli/variable"
 	"github.com/spf13/cobra"
-	"os"
 	//	"time"
 )
 
@@ -26,6 +27,7 @@ func Execute() {
 func init() {
 	cobra.OnInitialize(initConfig)
 	rootCmd.PersistentFlags().BoolVar(&variable.Verbose, "verbose", false, "Verbose output")
+	rootCmd.PersistentFlags().BoolVar(&variable.NoTrack, "notrack", false, "Do not track the command execution in Qovery telemetry")
 }
 
 func initConfig() {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -27,7 +27,6 @@ func Execute() {
 func init() {
 	cobra.OnInitialize(initConfig)
 	rootCmd.PersistentFlags().BoolVar(&variable.Verbose, "verbose", false, "Verbose output")
-	rootCmd.PersistentFlags().BoolVar(&variable.NoTrack, "notrack", false, "Do not track the command execution in Qovery telemetry")
 }
 
 func initConfig() {

--- a/utils/posthog.go
+++ b/utils/posthog.go
@@ -18,7 +18,7 @@ const EndOfExecutionErrorEventName = "cli-command-execution-error"
 func Capture(command *cobra.Command) {
 
 	// Do not track the command execution in Qovery telemetry
-	if flag := os.Getenv("QOVERY_TELEMETRY"); flag == "false" || flag == "FALSE" {
+	if flag := os.Getenv("QOVERY_TELEMETRY"); strings.ToLower(flag) == "false" {
 		return
 	}
 

--- a/utils/posthog.go
+++ b/utils/posthog.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/posthog/posthog-go"
+	"github.com/qovery/qovery-cli/variable"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -15,6 +16,12 @@ const EndOfExecutionEventName = "cli-command-execution-end"
 const EndOfExecutionErrorEventName = "cli-command-execution-error"
 
 func Capture(command *cobra.Command) {
+
+	// Do not track the command execution in Qovery telemetry
+	if flag := command.Flags().Lookup(variable.NoTrackFlag); flag != nil {
+		return
+	}
+
 	CaptureWithEvent(command, DefaultEventName)
 }
 

--- a/utils/posthog.go
+++ b/utils/posthog.go
@@ -1,12 +1,12 @@
 package utils
 
 import (
+	"os"
 	"runtime"
 	"strings"
 	"time"
 
 	"github.com/posthog/posthog-go"
-	"github.com/qovery/qovery-cli/variable"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -18,7 +18,7 @@ const EndOfExecutionErrorEventName = "cli-command-execution-error"
 func Capture(command *cobra.Command) {
 
 	// Do not track the command execution in Qovery telemetry
-	if flag := command.Flags().Lookup(variable.NoTrackFlag); flag != nil {
+	if flag := os.Getenv("QOVERY_TELEMETRY"); flag == "false" || flag == "FALSE" {
 		return
 	}
 

--- a/variable/notrack.go
+++ b/variable/notrack.go
@@ -1,0 +1,4 @@
+package variable
+
+var NoTrack bool
+var NoTrackFlag = "notrack"

--- a/variable/notrack.go
+++ b/variable/notrack.go
@@ -1,4 +1,0 @@
-package variable
-
-var NoTrack bool
-var NoTrackFlag = "notrack"


### PR DESCRIPTION
add an env var to avoid sending command execution to our telemetry system (posthog)