### PR TITLE
Bump k3d to v5.8.3

### DIFF
--- a/cmd/demo_scripts/create_qovery_demo.sh
+++ b/cmd/demo_scripts/create_qovery_demo.sh
@@ -191,7 +191,7 @@ install_deps() {
     echo "k3d already installed"
   else
     echo "Installing k3d"
-    curl -s https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | TAG=v5.6.3 bash
+    curl -s https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | TAG=v5.8.3 bash
   fi
 
   if which helm >/dev/null; then


### PR DESCRIPTION
Will testing the demo cluster, I was facing the following issue : 

Failed Cluster Start: Failed to start server k3d-local-demo-guillaume-server-0: Node k3d-local-demo-guillaume-server-0 failed to get ready: error waiting for log line k3s is up and running from node 'k3d-local-demo-guillaume-server-0': stopped returning log lines: node k3d-local-demo-guillaume-server-0 is running=true in status=restarting

Seems to be a known issue on k3d : https://github.com/k3d-io/k3d/issues/1481 and fixed in the last version.