### PR TITLE
CI: use Git tag to set `pkgver` in AUR workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,8 @@ jobs:
       # archlinux
       - name: Prepare AUR package
         run: |
-          version=$(awk -F'"' '/ci-version-check/{print $2}' pkg/version.go)
+          version="${GITHUB_REF_NAME:-}"
+          version="${version#v}"
           md5version=$(curl -sL https://github.com/Qovery/qovery-cli/archive/v${version}.tar.gz --output - | md5sum | awk '{ print $1 }')
           sed -i "s/pkgver=tbd/pkgver=$version/" PKGBUILD
           echo "md5sums=('${md5version}')" >> PKGBUILD


### PR DESCRIPTION
### What’s changed
* **Prepare AUR package** step now:
  1. Reads the version directly from the workflow tag (`${GITHUB_REF_NAME}`) and strips the leading `v`.
  2. Replaces `pkgver=tbd` with the real version.

### Why the old approach failed

The previous workflow tried to read the version with:

```bash
awk -F'"' '/ci-version-check/{print $2}' pkg/version.go
```
However, pkg/version.go no longer contains the ci-version-check marker (and when we build locally the string is often "unknown" until -ldflags injects the value).
As a result:

- version became an empty string.
- sed produced pkgver= (empty) in PKGBUILD.
- makepkg aborted with pkgver is not allowed to be empty, causing the GitHub Action to fail.

By deriving the version directly from the Git tag we:

- Guarantee that pkgver always matches the release being built.
- Remove the dependency on the internal layout of pkg/version.go.
- Avoid silent failures if that file changes again.

 **Publish AUR package** step is unchanged.

### How to test
Run the workflow on a tag, e.g. `v1.40.5`.  
`PKGBUILD` should contain:

```bash
pkgver=1.40.5
```
and the package should publish successfully to AUR.
