### PR TITLE
Fix: set proper perms on context file at each create/update

### DIFF
--- a/utils/context.go
+++ b/utils/context.go
@@ -15,6 +15,7 @@ import (
 )
 
 const ContextFileName = "context"
+const ContextFilePermissions = 0600
 
 type QoveryContext struct {
 	AccessToken           AccessToken  `json:"access_token"`
@@ -144,7 +145,12 @@ func StoreContext(context QoveryContext) error {
 		return err
 	}
 
-	return os.WriteFile(path, bytes, os.ModePerm)
+	err = os.Chmod(path, ContextFilePermissions)
+	if err != nil {
+		return err
+	}
+
+	return os.WriteFile(path, bytes, ContextFilePermissions)
 }
 
 func CurrentOrganization(promptContext bool) (Id, Name, error) {
@@ -398,7 +404,12 @@ func InitializeQoveryContext() error {
 		return err
 	}
 
-	err = os.WriteFile(path, []byte("{}"), os.ModePerm)
+	err = os.Chmod(path, ContextFilePermissions)
+	if err != nil {
+		return err
+	}
+
+	err = os.WriteFile(path, []byte("{}"), ContextFilePermissions)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
### Description
This PR addresses [QOV-1127](https://qovery.atlassian.net/browse/QOV-1127) by adding calls to `os.Chmod` before each context file write.
The change is made at each write operation, and not only after file creation, in order to change the permissions of existing files created by previous versions.

[QOV-1127]: https://qovery.atlassian.net/browse/QOV-1127?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ