### PR TITLE
feat(tooling): adopt mise for tool version management, upgrade to Go …

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,3 +1,5 @@
+version: 2
+
 builds:
   - main: main.go
     binary: qovery
@@ -10,45 +12,50 @@ builds:
     goarch:
       - amd64
       - arm64
+
 archives:
   - format_overrides:
     - goos: windows
       format: zip
+
 checksum:
   name_template: 'checksums.txt'
+
 changelog:
   sort: asc
   filters:
     exclude:
     - '^docs:'
     - '^test:'
+
 brews:
   - name: qovery-cli
-    goarm: 6
-    tap:
+    goarm: "6"
+    repository:
       owner: qovery
       name: homebrew-qovery-cli
     url_template: "https://github.com/Qovery/qovery-cli/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
     commit_author:
       name: qovery
       email: contact@qovery.com
-    folder: Formula
+    directory: Formula
     homepage: "https://docs.qovery.com"
     description: "Deploy modern application in seconds"
     skip_upload: false
     install: |
       bin.install "qovery"
-scoop:
-  url_template: "https://github.com/Qovery/qovery-cli/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
-  bucket:
-    owner: qovery
-    name: scoop-qovery-cli
-  commit_author:
-    name: qovery
-    email: contact@qovery.com
-  homepage: "https://docs.qovery.com"
-  description: "Deploy modern application in seconds"
-  license: GPL3
-  persist:
-  - "data"
-  - "config.toml"
+
+scoops:
+  - url_template: "https://github.com/Qovery/qovery-cli/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
+    repository:
+      owner: qovery
+      name: scoop-qovery-cli
+    commit_author:
+      name: qovery
+      email: contact@qovery.com
+    homepage: "https://docs.qovery.com"
+    description: "Deploy modern application in seconds"
+    license: GPL3
+    persist:
+    - "data"
+    - "config.toml"


### PR DESCRIPTION
…1.25.1

- Replace Makefile and justfile with .mise.toml for standardized tool management
- Mise automatically installs Go 1.25.1 and golangci-lint 2.5.0
- Upgrade Go toolchain from 1.24.6 to 1.25.1 (latest stable)
- Update .goreleaser.yml to v2 format (required by goreleaser-action@v6)
- All 8 tasks available: build, test, test-verbose, test-coverage, lint, clean, install, ci-local
- Ensures consistent tool versions across the entire team
- All tests passing with Go 1.25.1