### PR TITLE
feat: add --sort flag to environment variable commands

### DIFF
--- a/cmd/application_env_list.go
+++ b/cmd/application_env_list.go
@@ -71,11 +71,11 @@ var applicationEnvListCmd = &cobra.Command{
 		}
 
 		if jsonFlag {
-			utils.Println(utils.GetEnvVarJsonOutput(variables))
+			utils.Println(utils.GetEnvVarJsonOutput(variables, utils.SortKeys))
 			return
 		}
 
-		err = utils.PrintTable(envVarLines.Header(utils.PrettyPrint), envVarLines.Lines(utils.ShowValues, utils.PrettyPrint))
+		err = utils.PrintTable(envVarLines.Header(utils.PrettyPrint), envVarLines.Lines(utils.ShowValues, utils.PrettyPrint, utils.SortKeys))
 
 		if err != nil {
 			utils.PrintlnError(err)
@@ -93,6 +93,7 @@ func init() {
 	applicationEnvListCmd.Flags().StringVarP(&applicationName, "application", "n", "", "Application Name")
 	applicationEnvListCmd.Flags().BoolVarP(&utils.ShowValues, "show-values", "", false, "Show env var values")
 	applicationEnvListCmd.Flags().BoolVarP(&utils.PrettyPrint, "pretty-print", "", false, "Pretty print output")
+	applicationEnvListCmd.Flags().BoolVarP(&utils.SortKeys, "sort", "", false, "Sort environment variables by key")
 	applicationEnvListCmd.Flags().BoolVarP(&jsonFlag, "json", "", false, "JSON output")
 
 	_ = applicationEnvListCmd.MarkFlagRequired("application")

--- a/cmd/container_env_list.go
+++ b/cmd/container_env_list.go
@@ -71,11 +71,11 @@ var containerEnvListCmd = &cobra.Command{
 		}
 
 		if jsonFlag {
-			utils.Println(utils.GetEnvVarJsonOutput(variables))
+			utils.Println(utils.GetEnvVarJsonOutput(variables, utils.SortKeys))
 			return
 		}
 
-		err = utils.PrintTable(envVarLines.Header(utils.PrettyPrint), envVarLines.Lines(utils.ShowValues, utils.PrettyPrint))
+		err = utils.PrintTable(envVarLines.Header(utils.PrettyPrint), envVarLines.Lines(utils.ShowValues, utils.PrettyPrint, utils.SortKeys))
 
 		if err != nil {
 			utils.PrintlnError(err)
@@ -93,6 +93,7 @@ func init() {
 	containerEnvListCmd.Flags().StringVarP(&containerName, "container", "n", "", "Container Name")
 	containerEnvListCmd.Flags().BoolVarP(&utils.ShowValues, "show-values", "", false, "Show env var values")
 	containerEnvListCmd.Flags().BoolVarP(&utils.PrettyPrint, "pretty-print", "", false, "Pretty print output")
+	containerEnvListCmd.Flags().BoolVarP(&utils.SortKeys, "sort", "", false, "Sort environment variables by key")
 	containerEnvListCmd.Flags().BoolVarP(&jsonFlag, "json", "", false, "JSON output")
 
 	_ = containerEnvListCmd.MarkFlagRequired("container")

--- a/cmd/cronjob_env_list.go
+++ b/cmd/cronjob_env_list.go
@@ -71,11 +71,11 @@ var cronjobEnvListCmd = &cobra.Command{
 		}
 
 		if jsonFlag {
-			utils.Println(utils.GetEnvVarJsonOutput(variables))
+			utils.Println(utils.GetEnvVarJsonOutput(variables, utils.SortKeys))
 			return
 		}
 
-		err = utils.PrintTable(envVarLines.Header(utils.PrettyPrint), envVarLines.Lines(utils.ShowValues, utils.PrettyPrint))
+		err = utils.PrintTable(envVarLines.Header(utils.PrettyPrint), envVarLines.Lines(utils.ShowValues, utils.PrettyPrint, utils.SortKeys))
 
 		if err != nil {
 			utils.PrintlnError(err)
@@ -93,6 +93,7 @@ func init() {
 	cronjobEnvListCmd.Flags().StringVarP(&cronjobName, "cronjob", "n", "", "Cronjob Name")
 	cronjobEnvListCmd.Flags().BoolVarP(&utils.ShowValues, "show-values", "", false, "Show env var values")
 	cronjobEnvListCmd.Flags().BoolVarP(&utils.PrettyPrint, "pretty-print", "", false, "Pretty print output")
+	cronjobEnvListCmd.Flags().BoolVarP(&utils.SortKeys, "sort", "", false, "Sort environment variables by key")
 	cronjobEnvListCmd.Flags().BoolVarP(&jsonFlag, "json", "", false, "JSON output")
 
 	_ = cronjobEnvListCmd.MarkFlagRequired("cronjob")

--- a/cmd/environment_env_list.go
+++ b/cmd/environment_env_list.go
@@ -53,11 +53,11 @@ var environmentEnvListCmd = &cobra.Command{
 		}
 
 		if jsonFlag {
-			utils.Println(utils.GetEnvVarJsonOutput(variables))
+			utils.Println(utils.GetEnvVarJsonOutput(variables, utils.SortKeys))
 			return
 		}
 
-		err = utils.PrintTable(envVarLines.Header(utils.PrettyPrint), envVarLines.Lines(utils.ShowValues, utils.PrettyPrint))
+		err = utils.PrintTable(envVarLines.Header(utils.PrettyPrint), envVarLines.Lines(utils.ShowValues, utils.PrettyPrint, utils.SortKeys))
 		checkError(err)
 	},
 }
@@ -69,6 +69,7 @@ func init() {
 	environmentEnvListCmd.Flags().StringVarP(&environmentName, "environment", "", "", "Environment Name")
 	environmentEnvListCmd.Flags().BoolVarP(&utils.ShowValues, "show-values", "", false, "Show env var values")
 	environmentEnvListCmd.Flags().BoolVarP(&utils.PrettyPrint, "pretty-print", "", false, "Pretty print output")
+	environmentEnvListCmd.Flags().BoolVarP(&utils.SortKeys, "sort", "", false, "Sort environment variables by key")
 	environmentEnvListCmd.Flags().BoolVarP(&jsonFlag, "json", "", false, "JSON output")
 
 	_ = environmentEnvListCmd.MarkFlagRequired("project")

--- a/cmd/helm_env_list.go
+++ b/cmd/helm_env_list.go
@@ -77,11 +77,11 @@ var helmEnvListCmd = &cobra.Command{
 		}
 
 		if jsonFlag {
-			utils.Println(utils.GetEnvVarJsonOutput(variables))
+			utils.Println(utils.GetEnvVarJsonOutput(variables, utils.SortKeys))
 			return
 		}
 
-		err = utils.PrintTable(envVarLines.Header(utils.PrettyPrint), envVarLines.Lines(utils.ShowValues, utils.PrettyPrint))
+		err = utils.PrintTable(envVarLines.Header(utils.PrettyPrint), envVarLines.Lines(utils.ShowValues, utils.PrettyPrint, utils.SortKeys))
 
 		if err != nil {
 			utils.PrintlnError(err)
@@ -99,6 +99,7 @@ func init() {
 	helmEnvListCmd.Flags().StringVarP(&helmName, "helm", "n", "", "helm Name")
 	helmEnvListCmd.Flags().BoolVarP(&utils.ShowValues, "show-values", "", false, "Show env var values")
 	helmEnvListCmd.Flags().BoolVarP(&utils.PrettyPrint, "pretty-print", "", false, "Pretty print output")
+	helmEnvListCmd.Flags().BoolVarP(&utils.SortKeys, "sort", "", false, "Sort environment variables by key")
 	helmEnvListCmd.Flags().BoolVarP(&jsonFlag, "json", "", false, "JSON output")
 
 	_ = helmEnvListCmd.MarkFlagRequired("helm")

--- a/cmd/lifecycle_env_list.go
+++ b/cmd/lifecycle_env_list.go
@@ -72,11 +72,11 @@ var lifecycleEnvListCmd = &cobra.Command{
 		}
 
 		if jsonFlag {
-			utils.Println(utils.GetEnvVarJsonOutput(variables))
+			utils.Println(utils.GetEnvVarJsonOutput(variables, utils.SortKeys))
 			return
 		}
 
-		err = utils.PrintTable(envVarLines.Header(utils.PrettyPrint), envVarLines.Lines(utils.ShowValues, utils.PrettyPrint))
+		err = utils.PrintTable(envVarLines.Header(utils.PrettyPrint), envVarLines.Lines(utils.ShowValues, utils.PrettyPrint, utils.SortKeys))
 
 		if err != nil {
 			utils.PrintlnError(err)
@@ -94,6 +94,7 @@ func init() {
 	lifecycleEnvListCmd.Flags().StringVarP(&lifecycleName, "lifecycle", "n", "", "Lifecycle Name")
 	lifecycleEnvListCmd.Flags().BoolVarP(&utils.ShowValues, "show-values", "", false, "Show env var values")
 	lifecycleEnvListCmd.Flags().BoolVarP(&utils.PrettyPrint, "pretty-print", "", false, "Pretty print output")
+	lifecycleEnvListCmd.Flags().BoolVarP(&utils.SortKeys, "sort", "", false, "Sort environment variables by key")
 	lifecycleEnvListCmd.Flags().BoolVarP(&jsonFlag, "json", "", false, "JSON output")
 
 	_ = lifecycleEnvListCmd.MarkFlagRequired("lifecycle")

--- a/cmd/project_env_list.go
+++ b/cmd/project_env_list.go
@@ -37,11 +37,11 @@ var projectEnvListCmd = &cobra.Command{
 		}
 
 		if jsonFlag {
-			utils.Println(utils.GetEnvVarJsonOutput(variables))
+			utils.Println(utils.GetEnvVarJsonOutput(variables, utils.SortKeys))
 			return
 		}
 
-		err = utils.PrintTable(envVarLines.Header(utils.PrettyPrint), envVarLines.Lines(utils.ShowValues, utils.PrettyPrint))
+		err = utils.PrintTable(envVarLines.Header(utils.PrettyPrint), envVarLines.Lines(utils.ShowValues, utils.PrettyPrint, utils.SortKeys))
 		checkError(err)
 	},
 }
@@ -52,6 +52,7 @@ func init() {
 	projectEnvListCmd.Flags().StringVarP(&projectName, "project", "", "", "Project Name")
 	projectEnvListCmd.Flags().BoolVarP(&utils.ShowValues, "show-values", "", false, "Show env var values")
 	projectEnvListCmd.Flags().BoolVarP(&utils.PrettyPrint, "pretty-print", "", false, "Pretty print output")
+	projectEnvListCmd.Flags().BoolVarP(&utils.SortKeys, "sort", "", false, "Sort environment variables by key")
 	projectEnvListCmd.Flags().BoolVarP(&jsonFlag, "json", "", false, "JSON output")
 
 	_ = projectEnvListCmd.MarkFlagRequired("project")

--- a/utils/env_var.go
+++ b/utils/env_var.go
@@ -8,12 +8,14 @@ import (
 	"github.com/pterm/pterm"
 	"github.com/qovery/qovery-client-go"
 	"os"
+	"sort"
 	"strings"
 	"time"
 )
 
 var ShowValues bool
 var PrettyPrint bool
+var SortKeys bool
 var IsSecret bool
 var ApplicationScope string
 var JobScope string
@@ -63,10 +65,21 @@ func (e EnvVarLines) Header(prettyPrint bool) []string {
 	return []string{"Key", "Type", "Parent Key", "Value", "Updated at", "Service", "Scope"}
 }
 
-func (e EnvVarLines) Lines(showValues bool, prettyPrint bool) [][]string {
+func (e EnvVarLines) Lines(showValues bool, prettyPrint bool, sortKeys bool) [][]string {
 	var lines [][]string
 
-	for _, envVars := range e.lines {
+	// Get keys and optionally sort them
+	keys := make([]string, 0, len(e.lines))
+	for key := range e.lines {
+		keys = append(keys, key)
+	}
+	if sortKeys {
+		sort.Strings(keys)
+	}
+
+	// Iterate over sorted keys instead of map
+	for _, key := range keys {
+		envVars := e.lines[key]
 		for idx, envVar := range envVars {
 			x := envVar.Data(showValues)
 			if idx == 0 || !prettyPrint {
@@ -747,8 +760,18 @@ func getValueOrDefault(value *string) string {
 	}
 }
 
-func GetEnvVarJsonOutput(variables []EnvVarLineOutput) string {
+func GetEnvVarJsonOutput(variables []EnvVarLineOutput, sortKeys bool) string {
 	var results []interface{}
+
+	// Optionally sort variables by key before processing
+	if sortKeys {
+		sortedVars := make([]EnvVarLineOutput, len(variables))
+		copy(sortedVars, variables)
+		sort.Slice(sortedVars, func(i, j int) bool {
+			return sortedVars[i].Key < sortedVars[j].Key
+		})
+		variables = sortedVars
+	}
 
 	for _, v := range variables {
 		// TODO improve this


### PR DESCRIPTION
Add optional --sort flag to sort environment variables alphabetically by key.

Changes:
- Add SortKeys boolean flag in utils/env_var.go
- Modify EnvVarLines.Lines() to support sorting
- Modify GetEnvVarJsonOutput() to support sorting in JSON output
- Add --sort flag to all env list commands:
  * application env list
  * container env list
  * environment env list
  * project env list
  * helm env list
  * lifecycle env list
- Add --sort flag to env import command

The flag is optional and maintains backward compatibility. When enabled, variables are sorted alphabetically by key in both table and JSON output formats.