### PR TITLE
fix: update Dockerfile to use Go 1.25.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/r3m4q3r9/pub-mirror-go:1.24.2 as builder
+FROM public.ecr.aws/r3m4q3r9/pub-mirror-go:1.25.1 as builder
 
 ARG APP_VERSION=unknown
 


### PR DESCRIPTION
- Align with go.mod requirement (go 1.25.0)
- Fixes Docker build failure with v1.48.0