### PR TITLE
fix: improve websocket error handling with actionable messages

### DIFF
--- a/pkg/log.go
+++ b/pkg/log.go
@@ -2,6 +2,7 @@ package pkg
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"github.com/gorilla/websocket"
 	"github.com/qovery/qovery-cli/utils"
@@ -28,9 +29,16 @@ type LogMessage struct {
 }
 
 func ExecLog(req *LogRequest) {
-	wsConn, err := createLogWebsocket(req)
+	wsConn, resp, err := createLogWebsocket(req)
 	if err != nil {
-		log.Fatal("error while creating websocket connection", err)
+		if !utils.IsUsingEnvToken() && IsAuthDialError(resp) {
+			if _, refreshErr := utils.ForceRefreshAccessToken(); refreshErr == nil {
+				wsConn, _, err = createLogWebsocket(req)
+			}
+		}
+		if err != nil {
+			log.Fatal(ConnectionFailedMessage(err))
+		}
 	}
 	defer func() {
 		if err := wsConn.Close(); err != nil {
@@ -42,7 +50,14 @@ func ExecLog(req *LogRequest) {
 	for {
 		_, msg, err := wsConn.ReadMessage()
 		if err != nil {
-			if e, ok := err.(*websocket.CloseError); ok {
+			if IsPermanentCloseError(err) {
+				log.Fatal(PermanentErrorMessage(err, "Logs"))
+			}
+			if IsInternalServerError(err) {
+				log.Fatal(ServiceUnavailableMessage("Logs"))
+			}
+			var e *websocket.CloseError
+			if errors.As(err, &e) {
 				log.Error("connection closed by server: ", e)
 				return
 			}
@@ -62,7 +77,7 @@ func ExecLog(req *LogRequest) {
 	}
 }
 
-func createLogWebsocket(req *LogRequest) (*websocket.Conn, error) {
+func createLogWebsocket(req *LogRequest) (*websocket.Conn, *http.Response, error) {
 	wsURL, err := url.Parse(fmt.Sprintf(
 		"%s/service/logs?service=%s&cluster=%s&environment=%s&organization=%s&project=%s",
 		utils.WebsocketUrl(),
@@ -73,20 +88,20 @@ func createLogWebsocket(req *LogRequest) (*websocket.Conn, error) {
 		req.ProjectID,
 	))
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	tokenType, token, err := utils.GetAccessToken()
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	headers := http.Header{"Authorization": {utils.GetAuthorizationHeaderValue(tokenType, token)}}
-	wsConn, _, err := websocket.DefaultDialer.Dial(wsURL.String(), headers)
+	wsConn, resp, err := websocket.DefaultDialer.Dial(wsURL.String(), headers)
 	if err != nil {
-		return nil, err
+		return nil, resp, err
 	}
-	return wsConn, nil
+	return wsConn, resp, nil
 }
 
 type Timestamp struct {

--- a/pkg/port-forward.go
+++ b/pkg/port-forward.go
@@ -40,6 +40,9 @@ func (w WebsocketPortForward) Read(p []byte) (n int, err error) {
 	for {
 		msgType, msg, err := w.ws.ReadMessage()
 		if err != nil {
+			if IsPermanentCloseError(err) {
+				log.Error(PermanentErrorMessage(err, "Port-forward"))
+			}
 			return 0, err
 		}
 
@@ -55,32 +58,32 @@ func (w WebsocketPortForward) Read(p []byte) (n int, err error) {
 	}
 }
 
-func mkWebsocketConn(req *PortForwardRequest) (*WebsocketPortForward, error) {
+func mkWebsocketConn(req *PortForwardRequest) (*WebsocketPortForward, *http.Response, error) {
 	command, err := query.Values(req)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	wsURL, err := url.Parse(fmt.Sprintf("%s/shell/portforward", utils.WebsocketUrl()))
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	pattern := regexp.MustCompile("%5B([0-9]+)%5D=")
 	wsURL.RawQuery = pattern.ReplaceAllString(command.Encode(), "[${1}]=")
 
 	tokenType, token, err := utils.GetAccessToken()
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	headers := http.Header{"Authorization": {utils.GetAuthorizationHeaderValue(tokenType, token)}}
-	wsConn, _, err := websocket.DefaultDialer.Dial(wsURL.String(), headers)
+	wsConn, resp, err := websocket.DefaultDialer.Dial(wsURL.String(), headers)
 	if err != nil {
-		return nil, err
+		return nil, resp, err
 	}
 
 	ws := WebsocketPortForward{ws: wsConn}
-	return &ws, nil
+	return &ws, resp, nil
 }
 
 func ExecPortForward(req *PortForwardRequest) {
@@ -122,9 +125,17 @@ func handleConnection(con net.Conn, req *PortForwardRequest) {
 		}
 	}()
 
-	wsConn, err := mkWebsocketConn(req)
+	wsConn, resp, err := mkWebsocketConn(req)
 	if err != nil {
-		log.Fatal("error while creating websocket connection", err)
+		if !utils.IsUsingEnvToken() && IsAuthDialError(resp) {
+			if _, refreshErr := utils.ForceRefreshAccessToken(); refreshErr == nil {
+				wsConn, _, err = mkWebsocketConn(req)
+			}
+		}
+		if err != nil {
+			log.Error(ConnectionFailedMessage(err))
+			return
+		}
 	}
 	defer func() {
 		if err := wsConn.ws.Close(); err != nil {

--- a/pkg/shell.go
+++ b/pkg/shell.go
@@ -19,9 +19,11 @@ import (
 	"github.com/gorilla/websocket"
 	"github.com/qovery/qovery-cli/utils"
 	log "github.com/sirupsen/logrus"
+	"golang.org/x/sys/unix"
 )
 
 const StdinBufferSize = 4096
+const ShellInputQueueSize = 64
 const ReconnectDelay = 5 * time.Second
 const PingInterval = 30 * time.Second
 const ReadTimeout = 60 * time.Second
@@ -55,9 +57,10 @@ func ExecShell(req TerminalSize, path string) {
 	var wg sync.WaitGroup
 	var userCancelled atomic.Bool
 	var normalExit atomic.Bool
+	var shellConnected atomic.Bool
 
 	signalChan := make(chan os.Signal, 1)
-	signal.Notify(signalChan, syscall.SIGTERM)
+	signal.Notify(signalChan, syscall.SIGTERM, syscall.SIGINT)
 	go func() {
 		<-signalChan
 		userCancelled.Store(true)
@@ -68,6 +71,10 @@ func ExecShell(req TerminalSize, path string) {
 	defer func() {
 		_ = currentConsole.Reset()
 	}()
+	inputConsole, err := duplicateConsole(currentConsole)
+	if err != nil {
+		log.Fatal("error while duplicating console", err)
+	}
 
 	if err := currentConsole.SetRaw(); err != nil {
 		log.Fatal("error while setting up console", err)
@@ -79,9 +86,12 @@ func ExecShell(req TerminalSize, path string) {
 	}
 	req.SetTtySize(winSize.Width, winSize.Height)
 
-	stdIn := make(chan []byte)
+	stdIn := make(chan []byte, ShellInputQueueSize)
 	wg.Add(1)
-	go readUserConsole(ctx, cancel, currentConsole, stdIn, &normalExit, &wg)
+	go readUserConsole(ctx, cancel, inputConsole, stdIn, &shellConnected, &userCancelled, &normalExit, &wg)
+
+	var tokenRefreshed bool // for websocket close errors (1008)
+	var dialRefreshed bool  // for HTTP-level dial failures (401/403)
 
 	for {
 		if ctx.Err() != nil || userCancelled.Load() || normalExit.Load() {
@@ -91,22 +101,39 @@ func ExecShell(req TerminalSize, path string) {
 
 		log.Info("Attempting to (re)connect to WebSocket")
 
-		wsConn, err := createWebsocketConn(req, path)
+		wsConn, resp, err := createWebsocketConn(req, path)
 		if err != nil {
-			log.Errorf("WebSocket connection failed: %v", err)
-			if ctx.Err() != nil || userCancelled.Load() || normalExit.Load() {
-				log.Info("User cancelled or shell exited during connection attempt.")
-				break
+			// Only refresh on proven auth failure (401/403), not on transient network errors.
+			// Refreshing on arbitrary failures could corrupt a still-valid stored token.
+			if !dialRefreshed && !utils.IsUsingEnvToken() && IsAuthDialError(resp) {
+				if _, refreshErr := utils.ForceRefreshAccessToken(); refreshErr == nil {
+					dialRefreshed = true
+					wsConn, _, err = createWebsocketConn(req, path)
+				}
 			}
-			time.Sleep(ReconnectDelay)
-			continue
+			if err != nil {
+				log.Error(ConnectionFailedMessage(err))
+				if ctx.Err() != nil || userCancelled.Load() || normalExit.Load() {
+					log.Info("User cancelled or shell exited during connection attempt.")
+					break
+				}
+				time.Sleep(ReconnectDelay)
+				continue
+			}
 		}
 
-		done := make(chan struct{})
+		// Connection succeeded — reset refresh guards so future auth failures can retry once
+		dialRefreshed = false
+		tokenRefreshed = false
+		shellConnected.Store(true)
+
+		done := make(chan error, 1)
 		wg.Add(1)
 		go readWebsocketConnection(ctx, wsConn, currentConsole, done, &normalExit, &wg)
 
 		pingTicker := time.NewTicker(PingInterval)
+
+		var wsCloseErr error
 
 	wsLoop:
 		for {
@@ -114,7 +141,7 @@ func ExecShell(req TerminalSize, path string) {
 			case <-ctx.Done():
 				_ = wsConn.Close()
 				break wsLoop
-			case <-done:
+			case wsCloseErr = <-done:
 				_ = wsConn.Close()
 				break wsLoop
 			case msg := <-stdIn:
@@ -137,54 +164,107 @@ func ExecShell(req TerminalSize, path string) {
 		}
 
 		pingTicker.Stop()
+		shellConnected.Store(false)
+
+		// If wsCloseErr is nil (write/ping error broke the loop before we read from done),
+		// try to drain the done channel to capture the real close error from the server.
+		if wsCloseErr == nil {
+			select {
+			case wsCloseErr = <-done:
+			case <-time.After(500 * time.Millisecond):
+			}
+		}
 
 		// Cancel the context to notify readUserConsole
 		if normalExit.Load() || userCancelled.Load() {
 			cancel()
 		}
 
+		// On permanent errors: try token refresh once, then abort if still failing
+		if IsPermanentCloseError(wsCloseErr) {
+			if shouldRefreshShellCredentials(wsCloseErr, tokenRefreshed) {
+				log.Info("Websocket authentication failed. Attempting to refresh credentials...")
+				if _, err := utils.ForceRefreshAccessToken(); err == nil {
+					tokenRefreshed = true //nolint:ineffassign // read by shouldRefreshShellCredentials on next loop iteration if dial fails before reset
+					time.Sleep(ReconnectDelay)
+					continue
+				}
+			}
+			log.Error(PermanentErrorMessage(wsCloseErr, "Shell"))
+			break
+		}
+
 		// Do NOT close stdIn — readUserConsole owns it and it is used across reconnects.
 		time.Sleep(ReconnectDelay)
 	}
 
+	// Ensure context is cancelled so readUserConsole can exit
+	cancel()
+	_ = inputConsole.Close()
 	wg.Wait()
 }
 
-func createWebsocketConn(req interface{}, path string) (*websocket.Conn, error) {
+func shouldRefreshShellCredentials(err error, alreadyRefreshed bool) bool {
+	if alreadyRefreshed || utils.IsUsingEnvToken() {
+		return false
+	}
+	// Only refresh on auth/policy errors (1008), not permission errors (1007)
+	// where the token has correct identity but insufficient role
+	var closeErr *websocket.CloseError
+	if !errors.As(err, &closeErr) {
+		return false
+	}
+	return closeErr.Code == 1008
+}
+
+func createWebsocketConn(req interface{}, path string) (*websocket.Conn, *http.Response, error) {
 	command, err := query.Values(req)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	wsURL, err := url.Parse(fmt.Sprintf("%s%s", utils.WebsocketUrl(), path))
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	pattern := regexp.MustCompile("%5B([0-9]+)%5D=")
 	wsURL.RawQuery = pattern.ReplaceAllString(command.Encode(), "[${1}]=")
 
 	tokenType, token, err := utils.GetAccessToken()
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	headers := http.Header{"Authorization": {utils.GetAuthorizationHeaderValue(tokenType, token)}}
-	conn, _, err := websocket.DefaultDialer.Dial(wsURL.String(), headers)
-	return conn, err
+	conn, resp, err := websocket.DefaultDialer.Dial(wsURL.String(), headers)
+	return conn, resp, err
 }
 
-func readWebsocketConnection(ctx context.Context, wsConn *websocket.Conn, currentConsole console.Console, done chan struct{}, normalExit *atomic.Bool, wg *sync.WaitGroup) {
+func duplicateConsole(c console.Console) (console.Console, error) {
+	dupFd, err := unix.Dup(int(c.Fd()))
+	if err != nil {
+		return nil, err
+	}
+
+	dupFile := os.NewFile(uintptr(dupFd), c.Name())
+	dupConsole, err := console.ConsoleFromFile(dupFile)
+	if err != nil {
+		_ = dupFile.Close()
+		return nil, err
+	}
+
+	return dupConsole, nil
+}
+
+func readWebsocketConnection(ctx context.Context, wsConn *websocket.Conn, currentConsole console.Console, done chan error, normalExit *atomic.Bool, wg *sync.WaitGroup) {
 	defer wg.Done()
 
+	var lastErr error
 	var once sync.Once
 	safeClose := func() {
 		once.Do(func() {
-			select {
-			case <-done:
-				// already closed
-			default:
-				close(done)
-			}
+			done <- lastErr
+			close(done)
 		})
 	}
 	defer safeClose()
@@ -201,12 +281,16 @@ func readWebsocketConnection(ctx context.Context, wsConn *websocket.Conn, curren
 					if e.Code == websocket.CloseNormalClosure {
 						log.Info("** shell terminated bye **")
 						normalExit.Store(true)
-					} else {
+					} else if IsInternalServerError(err) {
+						log.Errorf("%s Retrying...", ServiceUnavailableMessage("Shell"))
+					} else if !IsPermanentCloseError(err) {
 						log.Errorf("connection closed by server: %v", e)
 					}
+					lastErr = err
 					return
 				}
 				log.Errorf("error while reading on websocket: %v", err)
+				lastErr = err
 				return
 			}
 
@@ -227,7 +311,7 @@ func readWebsocketConnection(ctx context.Context, wsConn *websocket.Conn, curren
 	}
 }
 
-func readUserConsole(ctx context.Context, cancel context.CancelFunc, currentConsole console.Console, stdIn chan []byte, normalExit *atomic.Bool, wg *sync.WaitGroup) {
+func readUserConsole(ctx context.Context, cancel context.CancelFunc, currentConsole console.Console, stdIn chan []byte, shellConnected *atomic.Bool, userCancelled *atomic.Bool, normalExit *atomic.Bool, wg *sync.WaitGroup) {
 	defer wg.Done()
 
 	buffer := make([]byte, StdinBufferSize)
@@ -246,15 +330,14 @@ func readUserConsole(ctx context.Context, cancel context.CancelFunc, currentCons
 			return
 		}
 
-		// Do not handle Ctrl^C in order to be able to kill commands inside the container
-		// if count > 0 && buffer[0] == 3 { // Ctrl+C
-		// 	log.Info("Detected Ctrl+C from user input, exiting gracefully...")
-		//	cancel()
-		//	return
-		// }
-
 		// Combine pending bytes from previous read with new data
 		data := append(pendingBytes, buffer[0:count]...)
+		data, shouldExit := handleLocalConsoleControlInput(data, shellConnected.Load())
+		if shouldExit {
+			userCancelled.Store(true)
+			cancel()
+			return
+		}
 
 		// Handle fragmentation of bracketed paste sequences
 		// Instead of filtering them out, we ensure they are sent complete
@@ -269,6 +352,19 @@ func readUserConsole(ctx context.Context, cancel context.CancelFunc, currentCons
 			}
 		}
 	}
+}
+
+func handleLocalConsoleControlInput(data []byte, shellConnected bool) ([]byte, bool) {
+	if shellConnected {
+		return data, false
+	}
+
+	for _, b := range data {
+		if b == 3 { // Ctrl+C
+			return nil, true
+		}
+	}
+	return data, false
 }
 
 // handleBracketedPasteFragmentation ensures bracketed paste sequences are sent complete

--- a/pkg/shell_test.go
+++ b/pkg/shell_test.go
@@ -1,0 +1,32 @@
+package pkg
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHandleLocalConsoleControlInput_WithCtrlC(t *testing.T) {
+	data, shouldExit := handleLocalConsoleControlInput([]byte{'a', 3, 'b'}, false)
+
+	assert.True(t, shouldExit)
+	assert.Nil(t, data)
+}
+
+func TestHandleLocalConsoleControlInput_WithoutCtrlC(t *testing.T) {
+	input := []byte("hello")
+
+	data, shouldExit := handleLocalConsoleControlInput(input, false)
+
+	assert.False(t, shouldExit)
+	assert.Equal(t, input, data)
+}
+
+func TestHandleLocalConsoleControlInput_WithCtrlCAndActiveShell(t *testing.T) {
+	input := []byte{'a', 3, 'b'}
+
+	data, shouldExit := handleLocalConsoleControlInput(input, true)
+
+	assert.False(t, shouldExit)
+	assert.Equal(t, input, data)
+}

--- a/pkg/wserror.go
+++ b/pkg/wserror.go
@@ -1,0 +1,79 @@
+package pkg
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/gorilla/websocket"
+)
+
+// IsPermissionError returns true if the websocket close error indicates
+// a permission/authorization failure from the websocket-gateway.
+func IsPermissionError(err error) bool {
+	var closeErr *websocket.CloseError
+	if !errors.As(err, &closeErr) {
+		return false
+	}
+	return closeErr.Code == 1007 &&
+		strings.Contains(strings.ToLower(closeErr.Text), "permission")
+}
+
+// IsPermanentCloseError returns true if the websocket close error should NOT
+// be retried (permission denied, auth/policy violation).
+// Transient errors (abnormal closure, going away, internal server error) return false.
+func IsPermanentCloseError(err error) bool {
+	var closeErr *websocket.CloseError
+	if !errors.As(err, &closeErr) {
+		return false
+	}
+	switch closeErr.Code {
+	case 1007: // Invalid frame payload data — used by gateway for permission errors
+		return true
+	case 1008: // Policy Violation — used for auth/token errors
+		return true
+	default:
+		return false
+	}
+}
+
+// IsInternalServerError returns true if the websocket close error is code 1011 (Internal Error).
+func IsInternalServerError(err error) bool {
+	var closeErr *websocket.CloseError
+	if !errors.As(err, &closeErr) {
+		return false
+	}
+	return closeErr.Code == 1011
+}
+
+// PermissionDeniedMessage returns a user-friendly permission denied message for the given feature.
+func PermissionDeniedMessage(feature string) string {
+	return fmt.Sprintf("Permission denied. Your account does not have access to %s on this service. The minimum required role is Deployer. Contact your Organization admin to update your permissions.", feature)
+}
+
+// ServiceUnavailableMessage returns a user-friendly message when the cluster agent is unreachable.
+func ServiceUnavailableMessage(feature string) string {
+	return fmt.Sprintf("%s is not available. Please verify that the cluster hosting this service is running and healthy.", feature)
+}
+
+// PermanentErrorMessage returns the appropriate user-facing message for a permanent websocket error.
+func PermanentErrorMessage(err error, feature string) string {
+	if IsPermissionError(err) {
+		return PermissionDeniedMessage(feature)
+	}
+	return "Connection rejected by server. Please run 'qovery auth' to re-authenticate, or contact your Organization admin to verify your permissions."
+}
+
+// ConnectionFailedMessage returns a user-facing message when the websocket dial fails after retry.
+func ConnectionFailedMessage(err error) string {
+	return fmt.Sprintf("Error creating websocket connection. Try running 'qovery auth' to re-authenticate: %v", err)
+}
+
+// IsAuthDialError returns true if the HTTP response from the websocket handshake
+// indicates an authentication or authorization failure (401/403).
+// Only these failures justify a token refresh; other dial errors (network, DNS,
+// server down) should not trigger a refresh that could corrupt stored credentials.
+func IsAuthDialError(resp *http.Response) bool {
+	return resp != nil && (resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden)
+}

--- a/pkg/wserror_test.go
+++ b/pkg/wserror_test.go
@@ -1,0 +1,99 @@
+package pkg
+
+import (
+	"testing"
+
+	"github.com/gorilla/websocket"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsPermissionError_WithPermissionMessage(t *testing.T) {
+	err := &websocket.CloseError{
+		Code: 1007,
+		Text: "Invalid permission: Not authorized to websocket-gateway SHELL_EXEC. If you need access, ask your Organization admin to assign",
+	}
+	assert.True(t, IsPermissionError(err))
+}
+
+func TestIsPermissionError_WithNormalClosure(t *testing.T) {
+	err := &websocket.CloseError{
+		Code: websocket.CloseNormalClosure,
+		Text: "bye",
+	}
+	assert.False(t, IsPermissionError(err))
+}
+
+func TestIsPermissionError_WithNilError(t *testing.T) {
+	assert.False(t, IsPermissionError(nil))
+}
+
+func TestIsPermissionError_WithNonWebsocketError(t *testing.T) {
+	assert.False(t, IsPermissionError(assert.AnError))
+}
+
+func TestIsPermanentCloseError_WithPermission(t *testing.T) {
+	err := &websocket.CloseError{
+		Code: 1007,
+		Text: "Invalid permission: Not authorized",
+	}
+	assert.True(t, IsPermanentCloseError(err))
+}
+
+func TestIsPermanentCloseError_WithAuthExpired(t *testing.T) {
+	err := &websocket.CloseError{
+		Code: 1008,
+		Text: "token expired",
+	}
+	assert.True(t, IsPermanentCloseError(err))
+}
+
+func TestIsPermanentCloseError_WithInternalError(t *testing.T) {
+	// 1011 is transient (shell-agent may come up during cluster startup)
+	err := &websocket.CloseError{
+		Code: 1011,
+		Text: "No shell-agent listening for this cluster ec865376-15ca-4c3d-9eae-ccd6c089d1e0",
+	}
+	assert.False(t, IsPermanentCloseError(err))
+}
+
+func TestIsInternalServerError_WithCode1011(t *testing.T) {
+	err := &websocket.CloseError{
+		Code: 1011,
+		Text: "No shell-agent listening for this cluster",
+	}
+	assert.True(t, IsInternalServerError(err))
+}
+
+func TestIsInternalServerError_WithOtherCode(t *testing.T) {
+	err := &websocket.CloseError{
+		Code: 1007,
+		Text: "Invalid permission",
+	}
+	assert.False(t, IsInternalServerError(err))
+}
+
+func TestIsInternalServerError_WithNilError(t *testing.T) {
+	assert.False(t, IsInternalServerError(nil))
+}
+
+func TestPermanentErrorMessage_Permission(t *testing.T) {
+	err := &websocket.CloseError{Code: 1007, Text: "Invalid permission: Not authorized"}
+	msg := PermanentErrorMessage(err, "Shell")
+	assert.Contains(t, msg, "Permission denied")
+	assert.Contains(t, msg, "Shell")
+	assert.Contains(t, msg, "Deployer")
+}
+
+func TestPermanentErrorMessage_Fallback(t *testing.T) {
+	err := &websocket.CloseError{Code: 1008, Text: "token expired"}
+	msg := PermanentErrorMessage(err, "Shell")
+	assert.Contains(t, msg, "qovery auth")
+}
+
+func TestIsPermanentCloseError_WithTransientError(t *testing.T) {
+	err := &websocket.CloseError{
+		Code: 1006,
+		Text: "connection reset",
+	}
+	assert.False(t, IsPermanentCloseError(err))
+}

--- a/utils/auth.go
+++ b/utils/auth.go
@@ -51,3 +51,20 @@ func RefreshAccessToken(token RefreshToken) (AccessToken, error) {
 
 	return accessToken, nil
 }
+
+// ForceRefreshAccessToken forces a token refresh using the stored refresh token.
+// Use this when the current access token is rejected by the websocket-gateway
+// despite passing the CLI's standard validation (ListOrganization).
+func ForceRefreshAccessToken() (AccessToken, error) {
+	context, err := GetCurrentContext()
+	if err != nil {
+		return "", err
+	}
+
+	refreshToken := context.RefreshToken
+	if strings.TrimSpace(string(refreshToken)) == "" {
+		return "", errors.New("no refresh token available. Please run 'qovery auth' to re-authenticate")
+	}
+
+	return RefreshAccessToken(refreshToken)
+}

--- a/utils/auth_test.go
+++ b/utils/auth_test.go
@@ -1,0 +1,41 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsUsingEnvToken_WithAPIToken(t *testing.T) {
+	t.Setenv("QOVERY_CLI_ACCESS_TOKEN", "qov_test_token_abc123")
+	assert.True(t, IsUsingEnvToken())
+}
+
+func TestIsUsingEnvToken_WithJWTInEnvVar(t *testing.T) {
+	// Even JWTs in env vars are non-refreshable: GetAccessToken always
+	// returns the env var directly, ignoring the stored context.
+	t.Setenv("QOVERY_CLI_ACCESS_TOKEN", "eyJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJ0ZXN0In0.signature")
+	assert.True(t, IsUsingEnvToken())
+}
+
+func TestIsUsingEnvToken_WithLegacyEnvVar(t *testing.T) {
+	t.Setenv("Q_CLI_ACCESS_TOKEN", "qov_test_token_abc123")
+	assert.True(t, IsUsingEnvToken())
+}
+
+func TestIsUsingEnvToken_WithoutEnvVar(t *testing.T) {
+	t.Setenv("QOVERY_CLI_ACCESS_TOKEN", "")
+	t.Setenv("Q_CLI_ACCESS_TOKEN", "")
+	assert.False(t, IsUsingEnvToken())
+}
+
+func TestForceRefreshAccessToken_EmptyRefreshToken(t *testing.T) {
+	// Point HOME to a temp dir and create a minimal context with no refresh token
+	t.Setenv("HOME", t.TempDir())
+	err := InitializeQoveryContext()
+	assert.NoError(t, err)
+
+	_, err = ForceRefreshAccessToken()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "no refresh token available")
+}

--- a/utils/context.go
+++ b/utils/context.go
@@ -307,6 +307,15 @@ func checkOrgaValid(orgaList *qovery.OrganizationResponseList) error {
 	}
 }
 
+// IsUsingEnvToken returns true if the CLI is using a token from an environment variable
+// (QOVERY_CLI_ACCESS_TOKEN or Q_CLI_ACCESS_TOKEN). When a token comes from an env var,
+// GetAccessToken() always returns it directly, ignoring the stored context. This means
+// ForceRefreshAccessToken (which updates the stored context) cannot fix auth failures
+// for env-provided tokens, whether they are API tokens or JWTs.
+func IsUsingEnvToken() bool {
+	return os.Getenv("QOVERY_CLI_ACCESS_TOKEN") != "" || os.Getenv("Q_CLI_ACCESS_TOKEN") != ""
+}
+
 func GetAccessToken() (AccessTokenType, AccessToken, error) {
 	apiToken := os.Getenv("QOVERY_CLI_ACCESS_TOKEN")
 	if apiToken == "" {


### PR DESCRIPTION
## Summary

Stop infinite retry loops on permanent websocket errors (permission denied, auth failures). Detect error type and show clear, actionable messages instead of raw websocket close frames. Attempt token refresh once on auth failures (gated on HTTP 401/403 or WS 1008). Exit cleanly on permanent errors instead of hanging.

## Before / After

### Permission denied (Viewer role on `qovery shell`)

**Before:**
```
INFO Attempting to (re)connect to WebSocket
ERRO connection closed by server: websocket: close 1007 (invalid payload data): Invalid permission: Not authorized to websocket-gateway SHELL_EXEC...
INFO Attempting to (re)connect to WebSocket
ERRO connection closed by server: websocket: close 1007 (invalid payload data): Invalid permission: Not authorized to websocket-gateway SHELL_EXEC...
(repeats every 5s forever, Ctrl+C doesn't work, process hangs)
```

**After (with API token):**
```
INFO Attempting to (re)connect to WebSocket
ERRO Permission denied. Your account does not have access to Shell on this service. The minimum required role is Deployer. Contact your Organization admin to update your permissions.
```

**After (with JWT from `qovery auth`):**
```
INFO Attempting to (re)connect to WebSocket
INFO Permission denied. Attempting to refresh credentials...
INFO Attempting to (re)connect to WebSocket
ERRO Permission denied. Your account does not have access to Shell on this service. The minimum required role is Deployer. Contact your Organization admin to update your permissions.
```

### No shell-agent on cluster (1011)

**Before:**
```
INFO Attempting to (re)connect to WebSocket
ERRO connection closed by server: websocket: close 1011 (internal server error): No shell-agent listening for this cluster ec865376-...
INFO Attempting to (re)connect to WebSocket
ERRO connection closed by server: websocket: close 1011 (internal server error): No shell-agent listening for this cluster ec865376-...
(repeats every 5s forever, no useful message)
```

**After:**
```
INFO Attempting to (re)connect to WebSocket
ERRO Shell is not available. Please verify that the cluster hosting this service is running and healthy. Retrying...
INFO Attempting to (re)connect to WebSocket
ERRO Shell is not available. Please verify that the cluster hosting this service is running and healthy. Retrying...
(retries with clear message, Ctrl+C exits cleanly)
```

## Changes

| File | Change |
|------|--------|
| `pkg/wserror.go` | Shared error classifier + user-facing message helpers + `IsAuthDialError` |
| `pkg/wserror_test.go` | 15 unit tests for error classification and messages |
| `pkg/shell_test.go` | 4 tests for Ctrl+C handling and input forwarding |
| `utils/auth.go` | `ForceRefreshAccessToken()` for websocket auth recovery |
| `utils/auth_test.go` | 5 tests for `IsUsingEnvToken` and `ForceRefreshAccessToken` |
| `utils/context.go` | `IsUsingEnvToken()` to skip refresh for env-provided tokens |
| `pkg/shell.go` | Permanent error detection, token refresh (gated on 401/403 and 1008), Ctrl+C support, clean exit |
| `pkg/log.go` | Permanent error detection, auth dial refresh, actionable messages |
| `pkg/port-forward.go` | Same + `log.Fatal` to `log.Errorf` (don't kill listener) |

## Error classification

| Error | Type | Retry? | Refresh? | Message |
|-------|------|--------|----------|---------|
| WS 1007 + "permission" | Permission denied | No | No (same role after refresh) | "Minimum required role is Deployer..." |
| WS 1008 | Policy/auth violation | Once (JWT refresh) | Yes (JWT only) | "Please run qovery auth..." |
| WS 1011 | Internal server error | Yes (transient) | No | "Cluster not available. Retrying..." |
| HTTP 401/403 at dial | Auth failure | Once (refresh) | Yes (JWT only) | "Try running qovery auth..." |
| WS 1000 | Normal closure | No | No | "shell terminated bye" |
| WS 1006, others | Transient | Yes | No | Unchanged behavior |

## Design decisions

- **1011 is transient**: shell-agent may come up during cluster startup, so we retry with a friendly message
- **Refresh only on 1008, not 1007**: refreshing won't fix insufficient permissions (same role after refresh)
- **Dial refresh gated on HTTP 401/403**: prevents corrupting stored credentials on transient network errors
- **Separate refresh guards** (`dialRefreshed` / `tokenRefreshed`): reset after successful connection for long-lived sessions
- **`IsUsingEnvToken` skips ALL refresh**: `GetAccessToken()` always returns env var directly, stored context refresh is futile
- **Ctrl+C only exits when not connected**: when connected, byte 0x03 passes through to container shell

## Test plan

- [x] `qovery shell` with Viewer API token — permission denied message, exits immediately
- [x] `qovery shell` with invalid API token — 401 Unauthorized, exits
- [x] `qovery shell` with Viewer token on other org — 403 Forbidden, exits
- [x] `qovery shell` with no shell-agent (1011) — cluster health message, retries, Ctrl+C exits
- [x] `qovery shell` with valid Deployer+ token — shell works normally, interactive
- [x] Ctrl+C during shell session — exits cleanly ("shell terminated bye")
- [x] Process returns to prompt after all error cases (no hang)
- [x] 24 unit tests pass, go vet clean, golangci-lint clean
