### PR TITLE
fix(shell): improve error message for agent response timeout

### DIFF
--- a/pkg/shell.go
+++ b/pkg/shell.go
@@ -201,7 +201,11 @@ func readWebsocketConnection(ctx context.Context, wsConn *websocket.Conn, curren
 					if e.Code == websocket.CloseNormalClosure {
 						log.Info("** shell terminated bye **")
 						normalExit.Store(true)
-					} else {
+					} else if IsAgentResponseTimeout(err) {
+						log.Errorf("Shell session timed out while the agent was connecting to your pod. Retrying...")
+					} else if IsInternalServerError(err) {
+						log.Errorf("%s Retrying...", ServiceUnavailableMessage("Shell"))
+					} else if !IsPermanentCloseError(err) {
 						log.Errorf("connection closed by server: %v", e)
 					}
 					return

--- a/pkg/wserror.go
+++ b/pkg/wserror.go
@@ -2,23 +2,10 @@ package pkg
 
 import (
 	"errors"
-	"fmt"
-	"net/http"
 	"strings"
 
 	"github.com/gorilla/websocket"
 )
-
-// IsPermissionError returns true if the websocket close error indicates
-// a permission/authorization failure from the websocket-gateway.
-func IsPermissionError(err error) bool {
-	var closeErr *websocket.CloseError
-	if !errors.As(err, &closeErr) {
-		return false
-	}
-	return closeErr.Code == 1007 &&
-		strings.Contains(strings.ToLower(closeErr.Text), "permission")
-}
 
 // IsPermanentCloseError returns true if the websocket close error should NOT
 // be retried (permission denied, auth/policy violation).
@@ -50,6 +37,10 @@ func IsInternalServerError(err error) bool {
 // IsAgentResponseTimeout returns true if the websocket close error indicates
 // the shell-agent timed out while attempting to open a shell session in the pod.
 // This is a transient error that resolves once the pod's Kubernetes exec API is responsive again.
+//
+// The matched substring is produced by:
+//   - rust-backend/grpc-gateway/src/lib/shell_gateway.rs  (TIMEOUT_AGENT_FIRST_RESPONSE)
+//   - rust-backend/grpc-gateway/src/lib/agent_gateway.rs  (DEFAULT_TIMEOUT_FIRST_MESSAGE)
 func IsAgentResponseTimeout(err error) bool {
 	var closeErr *websocket.CloseError
 	if !errors.As(err, &closeErr) {
@@ -58,33 +49,7 @@ func IsAgentResponseTimeout(err error) bool {
 	return closeErr.Code == 1011 && strings.Contains(closeErr.Text, "exceeded for receiving agent response")
 }
 
-// PermissionDeniedMessage returns a user-friendly permission denied message for the given feature.
-func PermissionDeniedMessage(feature string) string {
-	return fmt.Sprintf("Permission denied. Your account does not have access to %s on this service. The minimum required role is Deployer. Contact your Organization admin to update your permissions.", feature)
-}
-
 // ServiceUnavailableMessage returns a user-friendly message when the cluster agent is unreachable.
 func ServiceUnavailableMessage(feature string) string {
-	return fmt.Sprintf("%s is not available. Please verify that the cluster hosting this service is running and healthy.", feature)
-}
-
-// PermanentErrorMessage returns the appropriate user-facing message for a permanent websocket error.
-func PermanentErrorMessage(err error, feature string) string {
-	if IsPermissionError(err) {
-		return PermissionDeniedMessage(feature)
-	}
-	return "Connection rejected by server. Please run 'qovery auth' to re-authenticate, or contact your Organization admin to verify your permissions."
-}
-
-// ConnectionFailedMessage returns a user-facing message when the websocket dial fails after retry.
-func ConnectionFailedMessage(err error) string {
-	return fmt.Sprintf("Error creating websocket connection. Try running 'qovery auth' to re-authenticate: %v", err)
-}
-
-// IsAuthDialError returns true if the HTTP response from the websocket handshake
-// indicates an authentication or authorization failure (401/403).
-// Only these failures justify a token refresh; other dial errors (network, DNS,
-// server down) should not trigger a refresh that could corrupt stored credentials.
-func IsAuthDialError(resp *http.Response) bool {
-	return resp != nil && (resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden)
+	return feature + " is not available. Please verify that the cluster hosting this service is running and healthy."
 }

--- a/pkg/wserror.go
+++ b/pkg/wserror.go
@@ -1,0 +1,90 @@
+package pkg
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/gorilla/websocket"
+)
+
+// IsPermissionError returns true if the websocket close error indicates
+// a permission/authorization failure from the websocket-gateway.
+func IsPermissionError(err error) bool {
+	var closeErr *websocket.CloseError
+	if !errors.As(err, &closeErr) {
+		return false
+	}
+	return closeErr.Code == 1007 &&
+		strings.Contains(strings.ToLower(closeErr.Text), "permission")
+}
+
+// IsPermanentCloseError returns true if the websocket close error should NOT
+// be retried (permission denied, auth/policy violation).
+// Transient errors (abnormal closure, going away, internal server error) return false.
+func IsPermanentCloseError(err error) bool {
+	var closeErr *websocket.CloseError
+	if !errors.As(err, &closeErr) {
+		return false
+	}
+	switch closeErr.Code {
+	case 1007: // Invalid frame payload data — used by gateway for permission errors
+		return true
+	case 1008: // Policy Violation — used for auth/token errors
+		return true
+	default:
+		return false
+	}
+}
+
+// IsInternalServerError returns true if the websocket close error is code 1011 (Internal Error).
+func IsInternalServerError(err error) bool {
+	var closeErr *websocket.CloseError
+	if !errors.As(err, &closeErr) {
+		return false
+	}
+	return closeErr.Code == 1011
+}
+
+// IsAgentResponseTimeout returns true if the websocket close error indicates
+// the shell-agent timed out while attempting to open a shell session in the pod.
+// This is a transient error that resolves once the pod's Kubernetes exec API is responsive again.
+func IsAgentResponseTimeout(err error) bool {
+	var closeErr *websocket.CloseError
+	if !errors.As(err, &closeErr) {
+		return false
+	}
+	return closeErr.Code == 1011 && strings.Contains(closeErr.Text, "exceeded for receiving agent response")
+}
+
+// PermissionDeniedMessage returns a user-friendly permission denied message for the given feature.
+func PermissionDeniedMessage(feature string) string {
+	return fmt.Sprintf("Permission denied. Your account does not have access to %s on this service. The minimum required role is Deployer. Contact your Organization admin to update your permissions.", feature)
+}
+
+// ServiceUnavailableMessage returns a user-friendly message when the cluster agent is unreachable.
+func ServiceUnavailableMessage(feature string) string {
+	return fmt.Sprintf("%s is not available. Please verify that the cluster hosting this service is running and healthy.", feature)
+}
+
+// PermanentErrorMessage returns the appropriate user-facing message for a permanent websocket error.
+func PermanentErrorMessage(err error, feature string) string {
+	if IsPermissionError(err) {
+		return PermissionDeniedMessage(feature)
+	}
+	return "Connection rejected by server. Please run 'qovery auth' to re-authenticate, or contact your Organization admin to verify your permissions."
+}
+
+// ConnectionFailedMessage returns a user-facing message when the websocket dial fails after retry.
+func ConnectionFailedMessage(err error) string {
+	return fmt.Sprintf("Error creating websocket connection. Try running 'qovery auth' to re-authenticate: %v", err)
+}
+
+// IsAuthDialError returns true if the HTTP response from the websocket handshake
+// indicates an authentication or authorization failure (401/403).
+// Only these failures justify a token refresh; other dial errors (network, DNS,
+// server down) should not trigger a refresh that could corrupt stored credentials.
+func IsAuthDialError(resp *http.Response) bool {
+	return resp != nil && (resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden)
+}

--- a/pkg/wserror_test.go
+++ b/pkg/wserror_test.go
@@ -1,0 +1,84 @@
+package pkg
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/gorilla/websocket"
+)
+
+func TestIsAgentResponseTimeout(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "1011 with agent timeout reason",
+			err:  &websocket.CloseError{Code: 1011, Text: "Deadline of 60s exceeded for receiving agent response"},
+			want: true,
+		},
+		{
+			name: "1011 with different reason falls through to IsInternalServerError",
+			err:  &websocket.CloseError{Code: 1011, Text: "some other internal error"},
+			want: false,
+		},
+		{
+			name: "wrong close code",
+			err:  &websocket.CloseError{Code: 1007, Text: "exceeded for receiving agent response"},
+			want: false,
+		},
+		{
+			name: "non-websocket error",
+			err:  errors.New("plain network error"),
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsAgentResponseTimeout(tt.err); got != tt.want {
+				t.Errorf("IsAgentResponseTimeout() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsInternalServerError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"1011 matches", &websocket.CloseError{Code: 1011, Text: "anything"}, true},
+		{"1007 does not match", &websocket.CloseError{Code: 1007, Text: ""}, false},
+		{"non-websocket error", errors.New("plain error"), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsInternalServerError(tt.err); got != tt.want {
+				t.Errorf("IsInternalServerError() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsPermanentCloseError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"1007 is permanent", &websocket.CloseError{Code: 1007}, true},
+		{"1008 is permanent", &websocket.CloseError{Code: 1008}, true},
+		{"1011 is transient", &websocket.CloseError{Code: 1011}, false},
+		{"1000 is transient", &websocket.CloseError{Code: 1000}, false},
+		{"non-websocket error", errors.New("plain error"), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsPermanentCloseError(tt.err); got != tt.want {
+				t.Errorf("IsPermanentCloseError() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

When a `qovery shell` session drops and reconnects, the server can return a WebSocket close 1011 with reason `Deadline of Xs exceeded for receiving agent response`. The current CLI shows:

> Shell is not available. Please verify that the cluster hosting this service is running and healthy.

This is misleading — the cluster IS running, the shell-agent just took too long to exec into the pod (K8s API slowness).

## Fix

Add `IsAgentResponseTimeout` in `wserror.go` to detect this specific case (close 1011 + `exceeded for receiving agent response` in the reason), and show a more accurate message:

> Shell session timed out while the agent was connecting to your pod. Retrying...

The generic `IsInternalServerError` path (other 1011 errors → cluster unavailable message) is preserved unchanged.

## Related

Paired with a server-side fix in `rust-backend` that increases the agent response timeout from 30s to 60s.