### PR TITLE
feat(auth): add 'auth token' command to securely output access token

### DIFF
--- a/cmd/auth_token.go
+++ b/cmd/auth_token.go
@@ -11,27 +11,28 @@ import (
 
 var authTokenJsonFlag bool
 var authTokenAuthorizationHeaderFlag bool
+var authTokenPrintFlag bool
 
 var authTokenCmd = &cobra.Command{
 	Use:   "token",
-	Short: "Print the current valid access token",
-	Long: `Print the current valid access token (refreshing it if expired).
+	Short: "Output the current valid access token",
+	Long: `Output the current valid access token (refreshing it if expired).
 
-This command outputs a valid access token that can be used to make direct API calls 
+This command provides a valid access token that can be used to make direct API calls 
 to the Qovery API. The token is automatically refreshed if it has expired.
 
-By default, only the raw token value is printed to stdout (no newline formatting, 
-no extra text), making it safe for shell substitution.
+For security reasons, the token is not printed by default. You must explicitly 
+use --print or --json to output the token value.
 
 Examples:
-  # Get the raw token value (default)
-  qovery auth token
+  # Print the raw token value
+  qovery auth token --print
 
   # Use directly in a curl command
-  curl -H "Authorization: Bearer $(qovery auth token)" https://api.qovery.com/organization
+  curl -H "Authorization: Bearer $(qovery auth token --print)" https://api.qovery.com/organization
 
-  # Get the full Authorization header value
-  qovery auth token --authorization-header
+  # Print the full Authorization header value
+  qovery auth token --print --authorization-header
 
   # Get structured JSON output with token, type, expiration, and API URL
   qovery auth token --json
@@ -40,6 +41,12 @@ Examples:
   qovery auth token --json --authorization-header`,
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Capture(cmd)
+
+		// If neither --print nor --json is set, show help and available flags
+		if !authTokenPrintFlag && !authTokenJsonFlag {
+			_ = cmd.Help()
+			return
+		}
 
 		tokenType, token, err := utils.GetAccessToken()
 		if err != nil {
@@ -57,7 +64,7 @@ Examples:
 			return
 		}
 
-		// Default: just the raw token value
+		// --print: just the raw token value
 		fmt.Print(string(token))
 	},
 }
@@ -99,6 +106,7 @@ func printTokenAsJSON(tokenType utils.AccessTokenType, token utils.AccessToken) 
 
 func init() {
 	authCmd.AddCommand(authTokenCmd)
+	authTokenCmd.Flags().BoolVar(&authTokenPrintFlag, "print", false, "Print the raw access token value to stdout")
 	authTokenCmd.Flags().BoolVar(&authTokenJsonFlag, "json", false, "Output as JSON with token, type, expiration, and API URL")
 	authTokenCmd.Flags().BoolVar(&authTokenAuthorizationHeaderFlag, "authorization-header", false, "Output the full Authorization header value (e.g. 'Bearer eyJ...')")
 }

--- a/cmd/auth_token.go
+++ b/cmd/auth_token.go
@@ -1,0 +1,104 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/qovery/qovery-cli/utils"
+	"github.com/spf13/cobra"
+)
+
+var authTokenJsonFlag bool
+var authTokenAuthorizationHeaderFlag bool
+
+var authTokenCmd = &cobra.Command{
+	Use:   "token",
+	Short: "Print the current valid access token",
+	Long: `Print the current valid access token (refreshing it if expired).
+
+This command outputs a valid access token that can be used to make direct API calls 
+to the Qovery API. The token is automatically refreshed if it has expired.
+
+By default, only the raw token value is printed to stdout (no newline formatting, 
+no extra text), making it safe for shell substitution.
+
+Examples:
+  # Get the raw token value (default)
+  qovery auth token
+
+  # Use directly in a curl command
+  curl -H "Authorization: Bearer $(qovery auth token)" https://api.qovery.com/organization
+
+  # Get the full Authorization header value
+  qovery auth token --authorization-header
+
+  # Get structured JSON output with token, type, expiration, and API URL
+  qovery auth token --json
+
+  # Get JSON with the authorization header pre-formatted
+  qovery auth token --json --authorization-header`,
+	Run: func(cmd *cobra.Command, args []string) {
+		utils.Capture(cmd)
+
+		tokenType, token, err := utils.GetAccessToken()
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "Error: "+err.Error())
+			os.Exit(1)
+		}
+
+		if authTokenJsonFlag {
+			printTokenAsJSON(tokenType, token)
+			return
+		}
+
+		if authTokenAuthorizationHeaderFlag {
+			fmt.Print(utils.GetAuthorizationHeaderValue(tokenType, token))
+			return
+		}
+
+		// Default: just the raw token value
+		fmt.Print(string(token))
+	},
+}
+
+type authTokenJSONOutput struct {
+	AccessToken         string `json:"access_token,omitempty"`
+	TokenType           string `json:"token_type,omitempty"`
+	AuthorizationHeader string `json:"authorization_header,omitempty"`
+	ExpiresAt           string `json:"expires_at,omitempty"`
+	APIURL              string `json:"api_url"`
+}
+
+func printTokenAsJSON(tokenType utils.AccessTokenType, token utils.AccessToken) {
+	output := authTokenJSONOutput{
+		APIURL: utils.GetAPIBaseURL(),
+	}
+
+	if authTokenAuthorizationHeaderFlag {
+		output.AuthorizationHeader = utils.GetAuthorizationHeaderValue(tokenType, token)
+	} else {
+		output.AccessToken = string(token)
+		output.TokenType = string(tokenType)
+	}
+
+	// Try to get expiration from context (only available for Bearer tokens from context.json)
+	if tokenType == "Bearer" {
+		if ctx, err := utils.GetCurrentContext(); err == nil && !ctx.AccessTokenExpiration.IsZero() {
+			output.ExpiresAt = ctx.AccessTokenExpiration.UTC().Format("2006-01-02T15:04:05Z")
+		}
+	}
+
+	jsonBytes, err := json.MarshalIndent(output, "", "  ")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "Error: failed to marshal JSON output: "+err.Error())
+		os.Exit(1)
+	}
+	fmt.Println(string(jsonBytes))
+}
+
+func init() {
+	authCmd.AddCommand(authTokenCmd)
+	authTokenCmd.Flags().BoolVar(&authTokenJsonFlag, "json", false, "Output as JSON with token, type, expiration, and API URL")
+	authTokenCmd.Flags().BoolVar(&authTokenAuthorizationHeaderFlag, "authorization-header", false, "Output the full Authorization header value (e.g. 'Bearer eyJ...')")
+}


### PR DESCRIPTION
## Summary

- Adds `qovery auth token` subcommand that outputs a valid, auto-refreshed access token for use by external tools (e.g. Qovery AI Skill) that need to make direct Qovery API calls
- Eliminates the need for external tools to read `~/.qovery/context.json` directly to extract the JWT token
- Supports three output modes: raw token value (default), `--authorization-header` for the full header, and `--json` for structured output including expiration and API URL

## Motivation

The Qovery AI Skill increasingly needs to interact with the Qovery API directly for operations not yet available in the CLI. Currently, it reads the JWT from `~/.qovery/context.json`, which:
- Couples external tools to the CLI's internal file format
- Bypasses token validation and refresh logic (if the token is expired, the AI skill has no way to refresh it)

This command provides a clean, programmatic interface that handles token refresh automatically.

## Usage

```bash
# Get the raw token value (default - pipe-friendly)
TOKEN=$(qovery auth token)

# Use directly in curl
curl -H "Authorization: Bearer $(qovery auth token)" https://api.qovery.com/organization

# Get the full Authorization header value
qovery auth token --authorization-header

# Get structured JSON output
qovery auth token --json
# {
#   "access_token": "eyJ...",
#   "token_type": "Bearer",
#   "expires_at": "2026-05-08T12:00:00Z",
#   "api_url": "https://api.qovery.com"
# }

# JSON with authorization header pre-formatted
qovery auth token --json --authorization-header
# {
#   "authorization_header": "Bearer eyJ...",
#   "expires_at": "2026-05-08T12:00:00Z",
#   "api_url": "https://api.qovery.com"
# }
```

## Security

- Only the short-lived access token is exposed, **never** the refresh token
- Token is validated before output (via `GetAccessToken()` which calls the API)
- Errors go to stderr, stdout contains only the token — safe for `$()` substitution
- `~/.qovery/context.json` permissions remain `0600`

## Files Changed

| File | Change |
|------|--------|
| `cmd/auth_token.go` | New — command implementation |

No existing code was modified. The existing `qovery auth` command continues to work unchanged.