### PR TITLE
fix(shell): support non-TTY stdin for qovery shell --command

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -32,6 +32,7 @@ require (
 	github.com/tonistiigi/go-rosetta v0.0.0-20220804170347-3f4430f2d346
 	github.com/xlab/treeprint v1.2.0
 	golang.org/x/sys v0.40.0
+	golang.org/x/term v0.39.0
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/apimachinery v0.35.0
 	k8s.io/client-go v0.35.0
@@ -99,7 +100,6 @@ require (
 	go4.org v0.0.0-20260112195520-a5071408f32f // indirect
 	golang.org/x/net v0.49.0 // indirect
 	golang.org/x/oauth2 v0.34.0 // indirect
-	golang.org/x/term v0.39.0 // indirect
 	golang.org/x/text v0.33.0 // indirect
 	golang.org/x/time v0.14.0 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect

--- a/go.sum
+++ b/go.sum
@@ -218,12 +218,6 @@ github.com/pterm/pterm v0.12.36/go.mod h1:NjiL09hFhT/vWjQHSj1athJpx6H8cjpHXNAK5b
 github.com/pterm/pterm v0.12.40/go.mod h1:ffwPLwlbXxP+rxT0GsgDTzS3y3rmpAO1NMjUkGTYf8s=
 github.com/pterm/pterm v0.12.82 h1:+D9wYhCaeaK0FIQoZtqbNQuNpe2lB2tajKKsTd5paVQ=
 github.com/pterm/pterm v0.12.82/go.mod h1:TyuyrPjnxfwP+ccJdBTeWHtd/e0ybQHkOS/TakajZCw=
-github.com/qovery/qovery-client-go v0.0.0-20260216130502-8c24e675d431 h1:+Tsnzj/C7HlN7cj6ErV6ACDw6IkDZZ1tPBGjlWNZDII=
-github.com/qovery/qovery-client-go v0.0.0-20260216130502-8c24e675d431/go.mod h1:mcXeQtxR4AIGIBaWLhy52S16UwL8/1fcDywDuSK1BZ4=
-github.com/qovery/qovery-client-go v0.0.0-20260219080537-a4c08c90eb20 h1:KPidndWgVOSmtoSZs9h/EUOHzWe+dSUyQf9ei4SNNqI=
-github.com/qovery/qovery-client-go v0.0.0-20260219080537-a4c08c90eb20/go.mod h1:mcXeQtxR4AIGIBaWLhy52S16UwL8/1fcDywDuSK1BZ4=
-github.com/qovery/qovery-client-go v0.0.0-20260219090747-b1c8e03c2c2c h1:Hfs88HNHDeFzsAOQIc2gEC33edrmVK9oARql0wAuvo0=
-github.com/qovery/qovery-client-go v0.0.0-20260219090747-b1c8e03c2c2c/go.mod h1:mcXeQtxR4AIGIBaWLhy52S16UwL8/1fcDywDuSK1BZ4=
 github.com/qovery/qovery-client-go v0.0.0-20260409115633-dc18ee2d4749 h1:MqupJMa/VYobcExlGtfMFeWAdljOtJdaVaysmE2ugsk=
 github.com/qovery/qovery-client-go v0.0.0-20260409115633-dc18ee2d4749/go.mod h1:mcXeQtxR4AIGIBaWLhy52S16UwL8/1fcDywDuSK1BZ4=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=

--- a/pkg/shell.go
+++ b/pkg/shell.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"os"
@@ -19,6 +20,7 @@ import (
 	"github.com/gorilla/websocket"
 	"github.com/qovery/qovery-cli/utils"
 	log "github.com/sirupsen/logrus"
+	"golang.org/x/term"
 )
 
 const StdinBufferSize = 4096
@@ -67,24 +69,40 @@ func ExecShell(req TerminalSize, path string) {
 		cancel()
 	}()
 
-	currentConsole := console.Current()
-	defer func() {
-		_ = currentConsole.Reset()
-	}()
+	// Allocate a PTY only when stdin is a real terminal. When piped (e.g.
+	// `qovery shell --command ... < input` or invoked from automation),
+	// containerd/console.Current() panics with "provided file is not a console".
+	// In that case we behave like `kubectl exec -i`: pipe os.Stdin/os.Stdout
+	// straight through and leave TtyWidth/TtyHeight at zero so the server
+	// does not attempt to allocate a TTY on the remote side either.
+	interactive := term.IsTerminal(int(os.Stdin.Fd()))
 
-	if err := currentConsole.SetRaw(); err != nil {
-		log.Fatal("error while setting up console", err)
-	}
+	var stdinReader io.Reader = os.Stdin
+	var stdoutWriter io.Writer = os.Stdout
 
-	winSize, err := currentConsole.Size()
-	if err != nil {
-		log.Fatal("Cannot get terminal size", err)
+	if interactive {
+		currentConsole := console.Current()
+		defer func() {
+			_ = currentConsole.Reset()
+		}()
+
+		if err := currentConsole.SetRaw(); err != nil {
+			log.Fatal("error while setting up console", err)
+		}
+
+		winSize, err := currentConsole.Size()
+		if err != nil {
+			log.Fatal("Cannot get terminal size", err)
+		}
+		req.SetTtySize(winSize.Width, winSize.Height)
+
+		stdinReader = currentConsole
+		stdoutWriter = currentConsole
 	}
-	req.SetTtySize(winSize.Width, winSize.Height)
 
 	stdIn := make(chan []byte)
 	wg.Add(1)
-	go readUserConsole(ctx, cancel, currentConsole, stdIn, &normalExit, &wg)
+	go readUserConsole(ctx, cancel, stdinReader, interactive, stdIn, &normalExit, &wg)
 
 	for {
 		if ctx.Err() != nil || userCancelled.Load() || normalExit.Load() {
@@ -107,7 +125,7 @@ func ExecShell(req TerminalSize, path string) {
 
 		done := make(chan struct{})
 		wg.Add(1)
-		go readWebsocketConnection(ctx, cancel, wsConn, currentConsole, done, &normalExit, &wg)
+		go readWebsocketConnection(ctx, cancel, wsConn, stdoutWriter, done, &normalExit, &wg)
 
 		pingTicker := time.NewTicker(PingInterval)
 
@@ -178,7 +196,7 @@ func createWebsocketConn(req interface{}, path string) (*websocket.Conn, error) 
 	return conn, err
 }
 
-func readWebsocketConnection(ctx context.Context, cancel context.CancelFunc, wsConn *websocket.Conn, currentConsole console.Console, done chan struct{}, normalExit *atomic.Bool, wg *sync.WaitGroup) {
+func readWebsocketConnection(ctx context.Context, cancel context.CancelFunc, wsConn *websocket.Conn, out io.Writer, done chan struct{}, normalExit *atomic.Bool, wg *sync.WaitGroup) {
 	defer wg.Done()
 
 	var once sync.Once
@@ -242,7 +260,7 @@ func readWebsocketConnection(ctx context.Context, cancel context.CancelFunc, wsC
 				continue
 			}
 
-			if _, err = currentConsole.Write(msg); err != nil {
+			if _, err = out.Write(msg); err != nil {
 				log.Errorf("error while writing in console: %v", err)
 				return
 			}
@@ -250,7 +268,7 @@ func readWebsocketConnection(ctx context.Context, cancel context.CancelFunc, wsC
 	}
 }
 
-func readUserConsole(ctx context.Context, cancel context.CancelFunc, currentConsole console.Console, stdIn chan []byte, normalExit *atomic.Bool, wg *sync.WaitGroup) {
+func readUserConsole(ctx context.Context, cancel context.CancelFunc, in io.Reader, interactive bool, stdIn chan []byte, normalExit *atomic.Bool, wg *sync.WaitGroup) {
 	defer wg.Done()
 
 	buffer := make([]byte, StdinBufferSize)
@@ -262,8 +280,14 @@ func readUserConsole(ctx context.Context, cancel context.CancelFunc, currentCons
 			return
 		}
 
-		count, err := currentConsole.Read(buffer)
+		count, err := in.Read(buffer)
 		if err != nil {
+			// In non-interactive mode (piped stdin), EOF just means the input
+			// stream is exhausted; the remote command may still produce output,
+			// so let the websocket loop run until the server closes the session.
+			if !interactive && errors.Is(err, io.EOF) {
+				return
+			}
 			log.Error("error while reading on console:", err)
 			cancel()
 			return

--- a/pkg/shell.go
+++ b/pkg/shell.go
@@ -282,10 +282,25 @@ func readUserConsole(ctx context.Context, cancel context.CancelFunc, in io.Reade
 
 		count, err := in.Read(buffer)
 		if err != nil {
-			// In non-interactive mode (piped stdin), EOF just means the input
-			// stream is exhausted; the remote command may still produce output,
-			// so let the websocket loop run until the server closes the session.
+			// In non-interactive mode (piped stdin), EOF means the input stream
+			// is exhausted but the remote command may still produce output. We
+			// flush any buffered bytes, then send EOT (0x04) so the remote PTY
+			// line discipline propagates EOF to the remote process. Without
+			// this, commands like `cat < file` or `sh -s < script.sh` hang
+			// forever. The websocket loop stays open so we can drain remote
+			// stdout until the server closes the session.
 			if !interactive && errors.Is(err, io.EOF) {
+				if len(pendingBytes) > 0 {
+					select {
+					case <-ctx.Done():
+						return
+					case stdIn <- pendingBytes:
+					}
+				}
+				select {
+				case <-ctx.Done():
+				case stdIn <- []byte{0x04}:
+				}
 				return
 			}
 			log.Error("error while reading on console:", err)


### PR DESCRIPTION
## Summary

Fix `qovery shell --command ...` so it can be invoked from non-interactive contexts (CI, scripted automation, AI agent runners) without panicking, and so piped commands like `cat < file` or `sh -s < script.sh` actually finish instead of hanging on stdin.

Two related changes on the same branch:

- **`08129c2` Skip PTY allocation when stdin is not a TTY.** `pkg/shell.go` previously called `containerd/console.Current()` unconditionally; that function panics with `provided file is not a console` whenever the controlling terminal isn't available. The fix detects the TTY via `golang.org/x/term.IsTerminal(os.Stdin.Fd())`. When interactive, behavior is unchanged. When non-interactive, we pipe `os.Stdin`/`os.Stdout` straight through (no raw mode, no size detection) and leave `TtyWidth`/`TtyHeight` at zero. The read/write goroutines now take `io.Reader`/`io.Writer` instead of `console.Console` so the same code paths cover both modes.

- **`1986575` Propagate stdin EOF to the remote process via EOT.** Without this, the non-interactive reader returned silently on EOF and the remote command kept waiting for input. The fix flushes any buffered bracketed-paste bytes, then sends `0x04` (EOT) through the existing `stdIn` channel before returning. The remote side (which always runs under `AttachParams::interactive_tty()` in `rust-backend/shell-agent/src/lib/kubernetes.rs:90`) translates EOT to EOF via canonical-mode line discipline. Same mechanism the agent itself uses at `rust-backend/shell-agent/src/lib/shell.rs:79`. The websocket stays open so remote stdout drains until the server closes the session.

## Why this matters

Three real workflows are unblocked:

1. CI / scripted automation: `qovery shell --command "./run-migration.sh"` from a pipeline
2. Piped input: `cat seed.sql | qovery shell --command "psql"`
3. AI agent runners launching tools (e.g. Claude Code CLI) inside a remote dev environment without a human terminal

Interactive `qovery shell` from a developer terminal is unchanged.

## Test plan

- [x] `gofmt -l pkg/shell.go` clean
- [x] `go vet ./pkg/` clean
- [x] `go build ./pkg/... ./cmd/...` ok
- [x] `go test ./pkg/` (24 pass)
- [x] Smoke test: `qovery shell` from a real terminal still attaches with raw mode and resize
- [x] Smoke test: `echo "hello" | qovery-cli shell --command cat -- ...` outputs `hello` and exits cleanly
- [x] Smoke test: `qovery shell --command "./script.sh" < script.sh` runs to completion and exits

## Notes

- `golang.org/x/term` was already in the module graph as an indirect dep; `go mod tidy` promoted it to direct and cleaned up three stale `qovery-client-go` `go.sum` entries (collateral cleanup, not behavioral).
- Considered sending a websocket Close frame from the CLI on stdin EOF instead of EOT, but it tangles with the reconnect loop in `ExecShell` and risks tearing down stdout before it drains. Pure data-plane EOT is symmetric with what the agent does and requires no server-side changes.

Fix https://github.com/Qovery/qovery-cli/issues/632