### PR TITLE
feat(rde): add Remote Development Environment management commands

### DIFF
--- a/cmd/rde.go
+++ b/cmd/rde.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/pterm/pterm"
 	"github.com/qovery/qovery-cli/pkg/usercontext"
 	"github.com/qovery/qovery-cli/utils"
 	"github.com/qovery/qovery-client-go"
@@ -424,11 +425,11 @@ func rdeFindCustomRoleByName(client *qovery.APIClient, orgId string, roleName st
 	return nil, nil
 }
 
-// rdePrintEnvServices prints the services and their statuses for an environment.
+// rdePrintEnvServices prints the services and their statuses for an environment as a table.
 func rdePrintEnvServices(client *qovery.APIClient, envId string) {
 	statuses, _, err := client.EnvironmentMainCallsAPI.GetEnvironmentStatuses(context.Background(), envId).Execute()
 	if err != nil {
-		utils.Println("    (could not retrieve statuses)")
+		utils.Println("  (could not retrieve statuses)")
 		return
 	}
 
@@ -470,21 +471,38 @@ func rdePrintEnvServices(client *qovery.APIClient, envId string) {
 		}
 	}
 
-	printStatus := func(statuses []qovery.Status, typeName string) {
+	var data [][]string
+	collectStatuses := func(statuses []qovery.Status, typeName string) {
 		for _, s := range statuses {
 			name := nameMap[s.Id]
 			if name == "" {
 				name = s.Id
 			}
-			utils.Println(fmt.Sprintf("    %s [%s] (%s)", name, typeName, utils.GetStatusTextWithColor(s.State)))
+			data = append(data, []string{name, typeName, utils.GetStatusTextWithColor(s.State)})
 		}
 	}
 
-	printStatus(statuses.GetApplications(), "Application")
-	printStatus(statuses.GetContainers(), "Container")
-	printStatus(statuses.GetJobs(), "Job")
-	printStatus(statuses.GetDatabases(), "Database")
-	printStatus(statuses.GetHelms(), "Helm")
+	collectStatuses(statuses.GetApplications(), "Application")
+	collectStatuses(statuses.GetContainers(), "Container")
+	collectStatuses(statuses.GetJobs(), "Job")
+	collectStatuses(statuses.GetDatabases(), "Database")
+	collectStatuses(statuses.GetHelms(), "Helm")
+
+	if len(data) == 0 {
+		utils.Println("  No services found.")
+		return
+	}
+
+	_ = utils.PrintTable([]string{"Name", "Type", "Status"}, data)
+}
+
+// rdePrintKeyValueTable renders a key-value pterm table (no headers, like PrintContext).
+func rdePrintKeyValueTable(rows [][]string) {
+	tableData := pterm.TableData{}
+	for _, row := range rows {
+		tableData = append(tableData, row)
+	}
+	_ = pterm.DefaultTable.WithData(tableData).Render()
 }
 
 // ctx is a shorthand for context.Background() used in RDE commands.

--- a/cmd/rde.go
+++ b/cmd/rde.go
@@ -17,6 +17,7 @@ import (
 // RDE env var constants
 const rdeBlueprintProjectIdVar = "BLUEPRINT_PROJECT_ID"
 const rdeBlueprintKeyVar = "BLUEPRINT_KEY"
+const rdeOwnerEmailVar = "RDE_OWNER_EMAIL"
 
 // RDE shared flag variables
 var rdeBlueprintProjectName string
@@ -71,6 +72,7 @@ type rdeChildInfo struct {
 	EnvId              string
 	EnvName            string
 	BlueprintProjectId string
+	OwnerEmail         string
 }
 
 // --- RDE helper functions ---
@@ -251,12 +253,18 @@ func rdeListChildren(client *qovery.APIClient, orgId string, blueprintProjectId 
 				val = *bkVar.Value.Get()
 			}
 			if val == blueprintProjectId {
+				ownerEmail := ""
+				ownerVar := utils.FindEnvironmentVariableByKey(rdeOwnerEmailVar, vars)
+				if ownerVar != nil && ownerVar.Value.IsSet() && ownerVar.Value.Get() != nil {
+					ownerEmail = *ownerVar.Value.Get()
+				}
 				children = append(children, rdeChildInfo{
 					ProjectId:          project.Id,
 					ProjectName:        project.Name,
 					EnvId:              env.Id,
 					EnvName:            env.Name,
 					BlueprintProjectId: blueprintProjectId,
+					OwnerEmail:         ownerEmail,
 				})
 			}
 		}
@@ -319,12 +327,18 @@ func rdeFindChildByName(client *qovery.APIClient, orgId string, name string) (*r
 
 			// It's a child if BLUEPRINT_KEY != own project ID
 			if val != "" && val != project.Id {
+				ownerEmail := ""
+				ownerVar := utils.FindEnvironmentVariableByKey(rdeOwnerEmailVar, vars)
+				if ownerVar != nil && ownerVar.Value.IsSet() && ownerVar.Value.Get() != nil {
+					ownerEmail = *ownerVar.Value.Get()
+				}
 				return &rdeChildInfo{
 					ProjectId:          project.Id,
 					ProjectName:        project.Name,
 					EnvId:              env.Id,
 					EnvName:            env.Name,
 					BlueprintProjectId: val,
+					OwnerEmail:         ownerEmail,
 				}, nil
 			}
 		}

--- a/cmd/rde.go
+++ b/cmd/rde.go
@@ -1,0 +1,502 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/qovery/qovery-cli/pkg/usercontext"
+	"github.com/qovery/qovery-cli/utils"
+	"github.com/qovery/qovery-client-go"
+	"github.com/spf13/cobra"
+)
+
+// RDE env var constants
+const rdeBlueprintProjectIdVar = "BLUEPRINT_PROJECT_ID"
+const rdeBlueprintKeyVar = "BLUEPRINT_KEY"
+
+// RDE shared flag variables
+var rdeBlueprintProjectName string
+var rdeName string
+var rdeEmail string
+var rdeSkipRbac bool
+var rdeSkipInvite bool
+var rdeSkipDeploy bool
+var rdeUpgradeStrategy string
+var rdeConfirmFlag bool
+
+var rdeCmd = &cobra.Command{
+	Use:   "rde",
+	Short: "Manage Remote Development Environments (RDE)",
+	Long: `Manage Remote Development Environments (RDE).
+
+RDE allows platform teams to provision isolated, pre-configured development
+environments for developers. The system works as:
+
+  1. Blueprints: Template projects/environments that serve as the source for cloning
+  2. RDE instances: Cloned from a blueprint, with optional RBAC isolation and member invitation
+
+Blueprint identification uses environment variables:
+  - Project-level: BLUEPRINT_PROJECT_ID = <project ID> (marks a project as a blueprint)
+  - Environment-level: BLUEPRINT_KEY = <blueprint project ID> (links environments to their blueprint)`,
+	Run: func(cmd *cobra.Command, args []string) {
+		utils.Capture(cmd)
+
+		if len(args) == 0 {
+			_ = cmd.Help()
+			os.Exit(0)
+		}
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(rdeCmd)
+}
+
+// --- RDE helper types ---
+
+type rdeBlueprintInfo struct {
+	ProjectId   string
+	ProjectName string
+	EnvId       string
+	EnvName     string
+}
+
+type rdeChildInfo struct {
+	ProjectId          string
+	ProjectName        string
+	EnvId              string
+	EnvName            string
+	BlueprintProjectId string
+}
+
+// --- RDE helper functions ---
+
+// rdeGetOrgId resolves the organization ID from the --organization flag or stored context.
+func rdeGetOrgId(client *qovery.APIClient) (string, error) {
+	return usercontext.GetOrganizationContextResourceId(client, organizationName)
+}
+
+// rdeListBlueprintProjects finds all projects in the org that have the BLUEPRINT_PROJECT_ID env var.
+func rdeListBlueprintProjects(client *qovery.APIClient, orgId string) ([]rdeBlueprintInfo, error) {
+	projects, _, err := client.ProjectsAPI.ListProject(context.Background(), orgId).Execute()
+	if err != nil {
+		return nil, err
+	}
+
+	var blueprints []rdeBlueprintInfo
+
+	for _, project := range projects.GetResults() {
+		vars, err := utils.ListProjectVariables(client, project.Id)
+		if err != nil {
+			continue // skip projects we can't read vars for
+		}
+
+		bpVar := utils.FindEnvironmentVariableByKey(rdeBlueprintProjectIdVar, vars)
+		if bpVar == nil {
+			continue
+		}
+
+		// Verify the var value matches this project's ID
+		val := ""
+		if bpVar.Value.IsSet() && bpVar.Value.Get() != nil {
+			val = *bpVar.Value.Get()
+		}
+		if val != project.Id {
+			continue
+		}
+
+		// Find the first environment that has BLUEPRINT_KEY == projectId
+		envInfo, err := rdeFindBlueprintEnv(client, project.Id)
+		if err != nil || envInfo == nil {
+			// Blueprint project with no matching environment yet
+			blueprints = append(blueprints, rdeBlueprintInfo{
+				ProjectId:   project.Id,
+				ProjectName: project.Name,
+			})
+			continue
+		}
+
+		blueprints = append(blueprints, rdeBlueprintInfo{
+			ProjectId:   project.Id,
+			ProjectName: project.Name,
+			EnvId:       envInfo.EnvId,
+			EnvName:     envInfo.EnvName,
+		})
+	}
+
+	return blueprints, nil
+}
+
+// rdeFindBlueprintByProjectName finds a specific blueprint project by name.
+func rdeFindBlueprintByProjectName(client *qovery.APIClient, orgId string, name string) (*rdeBlueprintInfo, error) {
+	projects, _, err := client.ProjectsAPI.ListProject(context.Background(), orgId).Execute()
+	if err != nil {
+		return nil, err
+	}
+
+	for _, project := range projects.GetResults() {
+		if !strings.EqualFold(project.Name, name) {
+			continue
+		}
+
+		vars, err := utils.ListProjectVariables(client, project.Id)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read variables for project %s: %w", name, err)
+		}
+
+		bpVar := utils.FindEnvironmentVariableByKey(rdeBlueprintProjectIdVar, vars)
+		if bpVar == nil {
+			return nil, fmt.Errorf("project %s is not a blueprint (missing %s variable)", name, rdeBlueprintProjectIdVar)
+		}
+
+		val := ""
+		if bpVar.Value.IsSet() && bpVar.Value.Get() != nil {
+			val = *bpVar.Value.Get()
+		}
+		if val != project.Id {
+			return nil, fmt.Errorf("project %s has invalid %s variable (expected %s, got %s)", name, rdeBlueprintProjectIdVar, project.Id, val)
+		}
+
+		envInfo, err := rdeFindBlueprintEnv(client, project.Id)
+		if err != nil {
+			return nil, err
+		}
+
+		info := &rdeBlueprintInfo{
+			ProjectId:   project.Id,
+			ProjectName: project.Name,
+		}
+		if envInfo != nil {
+			info.EnvId = envInfo.EnvId
+			info.EnvName = envInfo.EnvName
+		}
+
+		return info, nil
+	}
+
+	return nil, fmt.Errorf("project %s not found", name)
+}
+
+type envInfo struct {
+	EnvId   string
+	EnvName string
+}
+
+// rdeFindBlueprintEnv gets the first environment in a blueprint project that has BLUEPRINT_KEY == projectId.
+func rdeFindBlueprintEnv(client *qovery.APIClient, projectId string) (*envInfo, error) {
+	environments, _, err := client.EnvironmentsAPI.ListEnvironment(context.Background(), projectId).Execute()
+	if err != nil {
+		return nil, err
+	}
+
+	for _, env := range environments.GetResults() {
+		vars, err := utils.ListEnvironmentVariables(client, env.Id)
+		if err != nil {
+			continue
+		}
+
+		bkVar := utils.FindEnvironmentVariableByKey(rdeBlueprintKeyVar, vars)
+		if bkVar == nil {
+			continue
+		}
+
+		val := ""
+		if bkVar.Value.IsSet() && bkVar.Value.Get() != nil {
+			val = *bkVar.Value.Get()
+		}
+		if val == projectId {
+			return &envInfo{EnvId: env.Id, EnvName: env.Name}, nil
+		}
+	}
+
+	return nil, nil
+}
+
+// rdeListChildren finds all projects whose environments have BLUEPRINT_KEY == blueprintProjectId (excluding the blueprint itself).
+func rdeListChildren(client *qovery.APIClient, orgId string, blueprintProjectId string) ([]rdeChildInfo, error) {
+	projects, _, err := client.ProjectsAPI.ListProject(context.Background(), orgId).Execute()
+	if err != nil {
+		return nil, err
+	}
+
+	var children []rdeChildInfo
+
+	for _, project := range projects.GetResults() {
+		if project.Id == blueprintProjectId {
+			continue // skip the blueprint itself
+		}
+
+		environments, _, err := client.EnvironmentsAPI.ListEnvironment(context.Background(), project.Id).Execute()
+		if err != nil {
+			continue
+		}
+
+		for _, env := range environments.GetResults() {
+			vars, err := utils.ListEnvironmentVariables(client, env.Id)
+			if err != nil {
+				continue
+			}
+
+			bkVar := utils.FindEnvironmentVariableByKey(rdeBlueprintKeyVar, vars)
+			if bkVar == nil {
+				continue
+			}
+
+			val := ""
+			if bkVar.Value.IsSet() && bkVar.Value.Get() != nil {
+				val = *bkVar.Value.Get()
+			}
+			if val == blueprintProjectId {
+				children = append(children, rdeChildInfo{
+					ProjectId:          project.Id,
+					ProjectName:        project.Name,
+					EnvId:              env.Id,
+					EnvName:            env.Name,
+					BlueprintProjectId: blueprintProjectId,
+				})
+			}
+		}
+	}
+
+	return children, nil
+}
+
+// rdeListAllChildren finds all RDE children across all blueprints.
+func rdeListAllChildren(client *qovery.APIClient, orgId string) ([]rdeChildInfo, error) {
+	blueprints, err := rdeListBlueprintProjects(client, orgId)
+	if err != nil {
+		return nil, err
+	}
+
+	var allChildren []rdeChildInfo
+	for _, bp := range blueprints {
+		children, err := rdeListChildren(client, orgId, bp.ProjectId)
+		if err != nil {
+			continue
+		}
+		allChildren = append(allChildren, children...)
+	}
+
+	return allChildren, nil
+}
+
+// rdeFindChildByName finds a child RDE project by its project name within the org.
+func rdeFindChildByName(client *qovery.APIClient, orgId string, name string) (*rdeChildInfo, error) {
+	projects, _, err := client.ProjectsAPI.ListProject(context.Background(), orgId).Execute()
+	if err != nil {
+		return nil, err
+	}
+
+	for _, project := range projects.GetResults() {
+		if !strings.EqualFold(project.Name, name) {
+			continue
+		}
+
+		environments, _, err := client.EnvironmentsAPI.ListEnvironment(context.Background(), project.Id).Execute()
+		if err != nil {
+			return nil, fmt.Errorf("failed to list environments for project %s: %w", name, err)
+		}
+
+		for _, env := range environments.GetResults() {
+			vars, err := utils.ListEnvironmentVariables(client, env.Id)
+			if err != nil {
+				continue
+			}
+
+			bkVar := utils.FindEnvironmentVariableByKey(rdeBlueprintKeyVar, vars)
+			if bkVar == nil {
+				continue
+			}
+
+			val := ""
+			if bkVar.Value.IsSet() && bkVar.Value.Get() != nil {
+				val = *bkVar.Value.Get()
+			}
+
+			// It's a child if BLUEPRINT_KEY != own project ID
+			if val != "" && val != project.Id {
+				return &rdeChildInfo{
+					ProjectId:          project.Id,
+					ProjectName:        project.Name,
+					EnvId:              env.Id,
+					EnvName:            env.Name,
+					BlueprintProjectId: val,
+				}, nil
+			}
+		}
+
+		return nil, fmt.Errorf("project %s exists but is not an RDE child (no %s variable pointing to a different project)", name, rdeBlueprintKeyVar)
+	}
+
+	return nil, fmt.Errorf("project %s not found", name)
+}
+
+// rdeGetEnvStatus gets the environment status as a StateEnum.
+func rdeGetEnvStatus(client *qovery.APIClient, envId string) (qovery.StateEnum, error) {
+	statuses, _, err := client.EnvironmentMainCallsAPI.GetEnvironmentStatuses(context.Background(), envId).Execute()
+	if err != nil {
+		return "", err
+	}
+	return statuses.Environment.State, nil
+}
+
+// rdeGetWorkspaceUrl gets the first application's public URL from the environment.
+func rdeGetWorkspaceUrl(client *qovery.APIClient, envId string) string {
+	apps, _, err := client.ApplicationsAPI.ListApplication(context.Background(), envId).Execute()
+	if err != nil || len(apps.GetResults()) == 0 {
+		return ""
+	}
+
+	appId := apps.GetResults()[0].Id
+	links, _, err := client.ApplicationMainCallsAPI.ListApplicationLinks(context.Background(), appId).Execute()
+	if err != nil || len(links.GetResults()) == 0 {
+		return ""
+	}
+
+	url := links.GetResults()[0].GetUrl()
+	return url
+}
+
+// rdeFormatUptime formats a deployment timestamp to human-readable uptime.
+func rdeFormatUptime(deployedAt *time.Time) string {
+	if deployedAt == nil {
+		return "-"
+	}
+
+	diff := time.Since(*deployedAt)
+	if diff < time.Minute {
+		return fmt.Sprintf("%ds", int(diff.Seconds()))
+	} else if diff < time.Hour {
+		return fmt.Sprintf("%dm", int(diff.Minutes()))
+	} else if diff < 24*time.Hour {
+		h := int(diff.Hours())
+		m := int(diff.Minutes()) % 60
+		return fmt.Sprintf("%dh %dm", h, m)
+	}
+	d := int(diff.Hours()) / 24
+	h := int(diff.Hours()) % 24
+	return fmt.Sprintf("%dd %dh", d, h)
+}
+
+// rdeGetLastDeployTime gets the last deployment timestamp for an environment.
+func rdeGetLastDeployTime(client *qovery.APIClient, envId string) *time.Time {
+	history, _, err := client.EnvironmentDeploymentHistoryAPI.ListEnvironmentDeploymentHistory(context.Background(), envId).Execute()
+	if err != nil || len(history.GetResults()) == 0 {
+		return nil
+	}
+
+	t := history.GetResults()[0].GetCreatedAt()
+	return &t
+}
+
+// rdeFindProjectByName finds a project by its exact name (case-insensitive) in the org.
+func rdeFindProjectByName(client *qovery.APIClient, orgId string, name string) (*qovery.Project, error) {
+	projects, _, err := client.ProjectsAPI.ListProject(context.Background(), orgId).Execute()
+	if err != nil {
+		return nil, err
+	}
+
+	for _, project := range projects.GetResults() {
+		if strings.EqualFold(project.Name, name) {
+			return &project, nil
+		}
+	}
+
+	return nil, fmt.Errorf("project %s not found", name)
+}
+
+// rdeFindCustomRoleByName finds a custom role by name in the org.
+func rdeFindCustomRoleByName(client *qovery.APIClient, orgId string, roleName string) (*qovery.OrganizationCustomRole, error) {
+	roles, _, err := client.OrganizationCustomRoleAPI.ListOrganizationCustomRoles(context.Background(), orgId).Execute()
+	if err != nil {
+		return nil, err
+	}
+
+	for _, role := range roles.GetResults() {
+		if role.Name != nil && strings.EqualFold(*role.Name, roleName) {
+			return &role, nil
+		}
+	}
+
+	return nil, nil
+}
+
+// rdePrintEnvServices prints the services and their statuses for an environment.
+func rdePrintEnvServices(client *qovery.APIClient, envId string) {
+	statuses, _, err := client.EnvironmentMainCallsAPI.GetEnvironmentStatuses(context.Background(), envId).Execute()
+	if err != nil {
+		utils.Println("    (could not retrieve statuses)")
+		return
+	}
+
+	// Build a name map from all service types
+	nameMap := make(map[string]string)
+
+	apps, _, _ := client.ApplicationsAPI.ListApplication(context.Background(), envId).Execute()
+	if apps != nil {
+		for _, app := range apps.GetResults() {
+			nameMap[app.Id] = app.GetName()
+		}
+	}
+
+	containers, _, _ := client.ContainersAPI.ListContainer(context.Background(), envId).Execute()
+	if containers != nil {
+		for _, c := range containers.GetResults() {
+			nameMap[c.Id] = c.Name
+		}
+	}
+
+	jobs, _, _ := client.JobsAPI.ListJobs(context.Background(), envId).Execute()
+	if jobs != nil {
+		for _, j := range jobs.GetResults() {
+			nameMap[utils.GetJobId(&j)] = utils.GetJobName(&j)
+		}
+	}
+
+	databases, _, _ := client.DatabasesAPI.ListDatabase(context.Background(), envId).Execute()
+	if databases != nil {
+		for _, db := range databases.GetResults() {
+			nameMap[db.Id] = db.Name
+		}
+	}
+
+	helms, _, _ := client.HelmsAPI.ListHelms(context.Background(), envId).Execute()
+	if helms != nil {
+		for _, h := range helms.GetResults() {
+			nameMap[h.Id] = h.Name
+		}
+	}
+
+	printStatus := func(statuses []qovery.Status, typeName string) {
+		for _, s := range statuses {
+			name := nameMap[s.Id]
+			if name == "" {
+				name = s.Id
+			}
+			utils.Println(fmt.Sprintf("    %s [%s] (%s)", name, typeName, utils.GetStatusTextWithColor(s.State)))
+		}
+	}
+
+	printStatus(statuses.GetApplications(), "Application")
+	printStatus(statuses.GetContainers(), "Container")
+	printStatus(statuses.GetJobs(), "Job")
+	printStatus(statuses.GetDatabases(), "Database")
+	printStatus(statuses.GetHelms(), "Helm")
+}
+
+// ctx is a shorthand for context.Background() used in RDE commands.
+func ctx() context.Context {
+	return context.Background()
+}
+
+// rdeBlueprintNameForProjectId resolves a blueprint project ID to its project name.
+func rdeBlueprintNameForProjectId(client *qovery.APIClient, projectId string) string {
+	project, _, err := client.ProjectMainCallsAPI.GetProject(context.Background(), projectId).Execute()
+	if err != nil {
+		return projectId // fallback to ID
+	}
+	return project.Name
+}

--- a/cmd/rde_blueprint.go
+++ b/cmd/rde_blueprint.go
@@ -1,0 +1,29 @@
+package cmd
+
+import (
+	"github.com/qovery/qovery-cli/utils"
+	"github.com/spf13/cobra"
+	"os"
+)
+
+var rdeBlueprintCmd = &cobra.Command{
+	Use:   "blueprint",
+	Short: "Manage RDE blueprints",
+	Long: `Manage RDE blueprint projects and environments.
+
+A blueprint is a project with a template environment that serves as the source
+for cloning new Remote Development Environments. Blueprints are identified by
+a project-level environment variable BLUEPRINT_PROJECT_ID.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		utils.Capture(cmd)
+
+		if len(args) == 0 {
+			_ = cmd.Help()
+			os.Exit(0)
+		}
+	},
+}
+
+func init() {
+	rdeCmd.AddCommand(rdeBlueprintCmd)
+}

--- a/cmd/rde_blueprint_create.go
+++ b/cmd/rde_blueprint_create.go
@@ -88,7 +88,7 @@ The project must already exist and contain at least one environment.`,
 		}
 
 		utils.Println("")
-		utils.Println(fmt.Sprintf("Blueprint registered successfully!"))
+		utils.Println("Blueprint registered successfully!")
 		utils.Println(fmt.Sprintf("  Project:     %s (%s)", project.Name, project.Id))
 		utils.Println(fmt.Sprintf("  Environment: %s (%s)", targetEnv.Name, targetEnv.Id))
 		utils.Println(fmt.Sprintf("  Console:     https://console.qovery.com/organization/%s/project/%s/environment/%s", orgId, project.Id, targetEnv.Id))

--- a/cmd/rde_blueprint_create.go
+++ b/cmd/rde_blueprint_create.go
@@ -1,0 +1,104 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/qovery/qovery-cli/utils"
+	"github.com/qovery/qovery-client-go"
+	"github.com/spf13/cobra"
+)
+
+var rdeBlueprintCreateCmd = &cobra.Command{
+	Use:   "create",
+	Short: "Register a project as an RDE blueprint",
+	Long: `Register an existing project as an RDE blueprint by setting the
+BLUEPRINT_PROJECT_ID project-level variable and BLUEPRINT_KEY on the
+first DEVELOPMENT environment.
+
+The project must already exist and contain at least one environment.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		utils.Capture(cmd)
+
+		client := utils.GetQoveryClientPanicInCaseOfError()
+		orgId, err := rdeGetOrgId(client)
+		checkError(err)
+
+		// Find the project by name
+		project, err := rdeFindProjectByName(client, orgId, rdeBlueprintProjectName)
+		if err != nil {
+			utils.PrintlnError(fmt.Errorf("project %s not found in organization", rdeBlueprintProjectName))
+			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
+		}
+
+		// Check if already registered as a blueprint
+		vars, err := utils.ListProjectVariables(client, project.Id)
+		if err == nil {
+			existing := utils.FindEnvironmentVariableByKey(rdeBlueprintProjectIdVar, vars)
+			if existing != nil {
+				utils.PrintlnInfo(fmt.Sprintf("Project %s is already registered as a blueprint", rdeBlueprintProjectName))
+				return
+			}
+		}
+
+		// Step 1: Create project-level env var BLUEPRINT_PROJECT_ID = projectId
+		utils.Println(fmt.Sprintf("Step 1/2: Setting %s on project %s...", rdeBlueprintProjectIdVar, rdeBlueprintProjectName))
+		err = utils.CreateProjectVariable(client, project.Id, rdeBlueprintProjectIdVar, project.Id, false)
+		if err != nil {
+			utils.PrintlnError(fmt.Errorf("failed to create project variable %s: %w", rdeBlueprintProjectIdVar, err))
+			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
+		}
+
+		// Step 2: Find first environment and set BLUEPRINT_KEY = projectId
+		utils.Println("Step 2/2: Setting BLUEPRINT_KEY on environment...")
+		environments, _, err := client.EnvironmentsAPI.ListEnvironment(context.Background(), project.Id).Execute()
+		if err != nil {
+			utils.PrintlnError(fmt.Errorf("failed to list environments: %w", err))
+			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
+		}
+
+		envResults := environments.GetResults()
+		if len(envResults) == 0 {
+			utils.PrintlnError(fmt.Errorf("project %s has no environments - create at least one environment first", rdeBlueprintProjectName))
+			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
+		}
+
+		// Prefer the first DEVELOPMENT environment, fallback to first env
+		var targetEnv *qovery.Environment
+		for _, env := range envResults {
+			if env.Mode == qovery.ENVIRONMENTMODEENUM_DEVELOPMENT {
+				targetEnv = &env
+				break
+			}
+		}
+		if targetEnv == nil {
+			targetEnv = &envResults[0]
+		}
+
+		err = utils.CreateEnvironmentVariable(client, project.Id, targetEnv.Id, rdeBlueprintKeyVar, project.Id, false)
+		if err != nil {
+			utils.PrintlnError(fmt.Errorf("failed to create environment variable %s: %w", rdeBlueprintKeyVar, err))
+			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
+		}
+
+		utils.Println("")
+		utils.Println(fmt.Sprintf("Blueprint registered successfully!"))
+		utils.Println(fmt.Sprintf("  Project:     %s (%s)", project.Name, project.Id))
+		utils.Println(fmt.Sprintf("  Environment: %s (%s)", targetEnv.Name, targetEnv.Id))
+		utils.Println(fmt.Sprintf("  Console:     https://console.qovery.com/organization/%s/project/%s/environment/%s", orgId, project.Id, targetEnv.Id))
+	},
+}
+
+func init() {
+	rdeBlueprintCmd.AddCommand(rdeBlueprintCreateCmd)
+	rdeBlueprintCreateCmd.Flags().StringVarP(&rdeBlueprintProjectName, "project", "p", "", "Project Name to register as a blueprint")
+	rdeBlueprintCreateCmd.Flags().StringVarP(&organizationName, "organization", "o", "", "Organization Name")
+
+	_ = rdeBlueprintCreateCmd.MarkFlagRequired("project")
+}

--- a/cmd/rde_blueprint_delete.go
+++ b/cmd/rde_blueprint_delete.go
@@ -1,0 +1,69 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/qovery/qovery-cli/utils"
+	"github.com/spf13/cobra"
+)
+
+var rdeBlueprintDeleteCmd = &cobra.Command{
+	Use:   "delete",
+	Short: "Unregister a project as an RDE blueprint",
+	Long: `Remove the BLUEPRINT_PROJECT_ID and BLUEPRINT_KEY environment variables
+from the project and its environment. This does NOT delete the project itself.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		utils.Capture(cmd)
+
+		client := utils.GetQoveryClientPanicInCaseOfError()
+		orgId, err := rdeGetOrgId(client)
+		checkError(err)
+
+		bp, err := rdeFindBlueprintByProjectName(client, orgId, rdeBlueprintProjectName)
+		if err != nil {
+			utils.PrintlnError(err)
+			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
+		}
+
+		// Delete project-level BLUEPRINT_PROJECT_ID var
+		utils.Println(fmt.Sprintf("Removing %s from project %s...", rdeBlueprintProjectIdVar, bp.ProjectName))
+		projectVars, err := utils.ListProjectVariables(client, bp.ProjectId)
+		if err == nil {
+			bpVar := utils.FindEnvironmentVariableByKey(rdeBlueprintProjectIdVar, projectVars)
+			if bpVar != nil {
+				_, err = client.VariableMainCallsAPI.DeleteVariable(ctx(), bpVar.Id).Execute()
+				if err != nil {
+					utils.PrintlnError(fmt.Errorf("failed to delete %s: %w", rdeBlueprintProjectIdVar, err))
+				}
+			}
+		}
+
+		// Delete environment-level BLUEPRINT_KEY var
+		if bp.EnvId != "" {
+			utils.Println(fmt.Sprintf("Removing %s from environment %s...", rdeBlueprintKeyVar, bp.EnvName))
+			envVars, err := utils.ListEnvironmentVariables(client, bp.EnvId)
+			if err == nil {
+				bkVar := utils.FindEnvironmentVariableByKey(rdeBlueprintKeyVar, envVars)
+				if bkVar != nil {
+					_, err = client.VariableMainCallsAPI.DeleteVariable(ctx(), bkVar.Id).Execute()
+					if err != nil {
+						utils.PrintlnError(fmt.Errorf("failed to delete %s: %w", rdeBlueprintKeyVar, err))
+					}
+				}
+			}
+		}
+
+		utils.Println("")
+		utils.Println(fmt.Sprintf("Blueprint %s unregistered. Project and environments are preserved.", bp.ProjectName))
+	},
+}
+
+func init() {
+	rdeBlueprintCmd.AddCommand(rdeBlueprintDeleteCmd)
+	rdeBlueprintDeleteCmd.Flags().StringVarP(&rdeBlueprintProjectName, "project", "p", "", "Blueprint Project Name to unregister")
+	rdeBlueprintDeleteCmd.Flags().StringVarP(&organizationName, "organization", "o", "", "Organization Name")
+
+	_ = rdeBlueprintDeleteCmd.MarkFlagRequired("project")
+}

--- a/cmd/rde_blueprint_deploy.go
+++ b/cmd/rde_blueprint_deploy.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/pterm/pterm"
 	"github.com/qovery/qovery-cli/utils"
 	"github.com/qovery/qovery-client-go"
 	"github.com/spf13/cobra"
@@ -34,7 +35,6 @@ var rdeBlueprintDeployCmd = &cobra.Command{
 			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
-		utils.Println(fmt.Sprintf("Deploying blueprint %s...", bp.ProjectName))
 		_, _, err = client.EnvironmentActionsAPI.DeployEnvironment(context.Background(), bp.EnvId).Execute()
 		if err != nil {
 			utils.PrintlnError(fmt.Errorf("deploy failed: %w", err))
@@ -42,7 +42,7 @@ var rdeBlueprintDeployCmd = &cobra.Command{
 			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
-		utils.Println("Blueprint deployment triggered.")
+		utils.Println(fmt.Sprintf("Request to deploy blueprint %s has been queued..", pterm.FgBlue.Sprintf("%s", bp.ProjectName)))
 
 		if watchFlag {
 			time.Sleep(3 * time.Second)

--- a/cmd/rde_blueprint_deploy.go
+++ b/cmd/rde_blueprint_deploy.go
@@ -1,0 +1,61 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/qovery/qovery-cli/utils"
+	"github.com/qovery/qovery-client-go"
+	"github.com/spf13/cobra"
+)
+
+var rdeBlueprintDeployCmd = &cobra.Command{
+	Use:   "deploy",
+	Short: "Deploy a blueprint environment",
+	Run: func(cmd *cobra.Command, args []string) {
+		utils.Capture(cmd)
+
+		client := utils.GetQoveryClientPanicInCaseOfError()
+		orgId, err := rdeGetOrgId(client)
+		checkError(err)
+
+		bp, err := rdeFindBlueprintByProjectName(client, orgId, rdeBlueprintProjectName)
+		if err != nil {
+			utils.PrintlnError(err)
+			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
+		}
+
+		if bp.EnvId == "" {
+			utils.PrintlnError(fmt.Errorf("blueprint %s has no environment with %s set", bp.ProjectName, rdeBlueprintKeyVar))
+			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
+		}
+
+		utils.Println(fmt.Sprintf("Deploying blueprint %s...", bp.ProjectName))
+		_, _, err = client.EnvironmentActionsAPI.DeployEnvironment(context.Background(), bp.EnvId).Execute()
+		if err != nil {
+			utils.PrintlnError(fmt.Errorf("deploy failed: %w", err))
+			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
+		}
+
+		utils.Println("Blueprint deployment triggered.")
+
+		if watchFlag {
+			time.Sleep(3 * time.Second)
+			utils.WatchEnvironment(bp.EnvId, qovery.STATEENUM_DEPLOYED, client)
+		}
+	},
+}
+
+func init() {
+	rdeBlueprintCmd.AddCommand(rdeBlueprintDeployCmd)
+	rdeBlueprintDeployCmd.Flags().StringVarP(&rdeBlueprintProjectName, "project", "p", "", "Blueprint Project Name")
+	rdeBlueprintDeployCmd.Flags().StringVarP(&organizationName, "organization", "o", "", "Organization Name")
+	rdeBlueprintDeployCmd.Flags().BoolVarP(&watchFlag, "watch", "w", false, "Watch deployment status until it's ready or an error occurs")
+
+	_ = rdeBlueprintDeployCmd.MarkFlagRequired("project")
+}

--- a/cmd/rde_blueprint_list.go
+++ b/cmd/rde_blueprint_list.go
@@ -1,0 +1,86 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/qovery/qovery-cli/utils"
+	"github.com/spf13/cobra"
+)
+
+var rdeBlueprintListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List all RDE blueprints",
+	Run: func(cmd *cobra.Command, args []string) {
+		utils.Capture(cmd)
+
+		client := utils.GetQoveryClientPanicInCaseOfError()
+		orgId, err := rdeGetOrgId(client)
+		checkError(err)
+
+		blueprints, err := rdeListBlueprintProjects(client, orgId)
+		checkError(err)
+
+		if len(blueprints) == 0 {
+			utils.Println("No RDE blueprints found.")
+			return
+		}
+
+		if jsonFlag {
+			var results []interface{}
+			for _, bp := range blueprints {
+				status := ""
+				if bp.EnvId != "" {
+					s, err := rdeGetEnvStatus(client, bp.EnvId)
+					if err == nil {
+						status = string(s)
+					}
+				}
+				results = append(results, map[string]interface{}{
+					"project_id":   bp.ProjectId,
+					"project_name": bp.ProjectName,
+					"env_id":       bp.EnvId,
+					"env_name":     bp.EnvName,
+					"status":       status,
+				})
+			}
+			j, _ := json.Marshal(results)
+			utils.Println(string(j))
+			return
+		}
+
+		var data [][]string
+		for _, bp := range blueprints {
+			status := "NO_ENV"
+			if bp.EnvId != "" {
+				s, err := rdeGetEnvStatus(client, bp.EnvId)
+				if err == nil {
+					status = string(utils.GetStatusTextWithColor(s))
+				}
+			}
+
+			envName := "-"
+			if bp.EnvName != "" {
+				envName = bp.EnvName
+			}
+
+			data = append(data, []string{bp.ProjectName, envName, status, bp.ProjectId})
+		}
+
+		err = utils.PrintTable([]string{"Project Name", "Environment", "Status", "Project ID"}, data)
+		if err != nil {
+			utils.PrintlnError(err)
+			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
+		}
+
+		utils.Println(fmt.Sprintf("\nTotal: %d blueprint(s)", len(blueprints)))
+	},
+}
+
+func init() {
+	rdeBlueprintCmd.AddCommand(rdeBlueprintListCmd)
+	rdeBlueprintListCmd.Flags().StringVarP(&organizationName, "organization", "o", "", "Organization Name")
+	rdeBlueprintListCmd.Flags().BoolVarP(&jsonFlag, "json", "", false, "JSON output")
+}

--- a/cmd/rde_blueprint_register.go
+++ b/cmd/rde_blueprint_register.go
@@ -10,8 +10,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var rdeBlueprintCreateCmd = &cobra.Command{
-	Use:   "create",
+var rdeBlueprintRegisterCmd = &cobra.Command{
+	Use:   "register",
 	Short: "Register a project as an RDE blueprint",
 	Long: `Register an existing project as an RDE blueprint by setting the
 BLUEPRINT_PROJECT_ID project-level variable and BLUEPRINT_KEY on the
@@ -96,9 +96,9 @@ The project must already exist and contain at least one environment.`,
 }
 
 func init() {
-	rdeBlueprintCmd.AddCommand(rdeBlueprintCreateCmd)
-	rdeBlueprintCreateCmd.Flags().StringVarP(&rdeBlueprintProjectName, "project", "p", "", "Project Name to register as a blueprint")
-	rdeBlueprintCreateCmd.Flags().StringVarP(&organizationName, "organization", "o", "", "Organization Name")
+	rdeBlueprintCmd.AddCommand(rdeBlueprintRegisterCmd)
+	rdeBlueprintRegisterCmd.Flags().StringVarP(&rdeBlueprintProjectName, "project", "p", "", "Project Name to register as a blueprint")
+	rdeBlueprintRegisterCmd.Flags().StringVarP(&organizationName, "organization", "o", "", "Organization Name")
 
-	_ = rdeBlueprintCreateCmd.MarkFlagRequired("project")
+	_ = rdeBlueprintRegisterCmd.MarkFlagRequired("project")
 }

--- a/cmd/rde_blueprint_status.go
+++ b/cmd/rde_blueprint_status.go
@@ -1,0 +1,65 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/qovery/qovery-cli/utils"
+	"github.com/spf13/cobra"
+)
+
+var rdeBlueprintStatusCmd = &cobra.Command{
+	Use:   "status",
+	Short: "Show detailed status of a blueprint",
+	Run: func(cmd *cobra.Command, args []string) {
+		utils.Capture(cmd)
+
+		client := utils.GetQoveryClientPanicInCaseOfError()
+		orgId, err := rdeGetOrgId(client)
+		checkError(err)
+
+		bp, err := rdeFindBlueprintByProjectName(client, orgId, rdeBlueprintProjectName)
+		if err != nil {
+			utils.PrintlnError(err)
+			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
+		}
+
+		utils.Println(fmt.Sprintf("Blueprint: %s", bp.ProjectName))
+		utils.Println(fmt.Sprintf("  Project:     %s", bp.ProjectId))
+
+		if bp.EnvId == "" {
+			utils.Println("  Environment: (none)")
+			return
+		}
+
+		utils.Println(fmt.Sprintf("  Environment: %s (%s)", bp.EnvName, bp.EnvId))
+
+		status, err := rdeGetEnvStatus(client, bp.EnvId)
+		if err == nil {
+			utils.Println(fmt.Sprintf("  Status:      %s", utils.GetStatusTextWithColor(status)))
+		}
+
+		utils.Println(fmt.Sprintf("  Console:     https://console.qovery.com/organization/%s/project/%s/environment/%s", orgId, bp.ProjectId, bp.EnvId))
+
+		// Count children
+		children, err := rdeListChildren(client, orgId, bp.ProjectId)
+		if err == nil {
+			utils.Println(fmt.Sprintf("  Children:    %d RDE(s)", len(children)))
+		}
+
+		// List services
+		utils.Println("")
+		utils.Println("  Services:")
+
+		rdePrintEnvServices(client, bp.EnvId)
+	},
+}
+
+func init() {
+	rdeBlueprintCmd.AddCommand(rdeBlueprintStatusCmd)
+	rdeBlueprintStatusCmd.Flags().StringVarP(&rdeBlueprintProjectName, "project", "p", "", "Blueprint Project Name")
+	rdeBlueprintStatusCmd.Flags().StringVarP(&organizationName, "organization", "o", "", "Organization Name")
+
+	_ = rdeBlueprintStatusCmd.MarkFlagRequired("project")
+}

--- a/cmd/rde_blueprint_status.go
+++ b/cmd/rde_blueprint_status.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/pterm/pterm"
 	"github.com/qovery/qovery-cli/utils"
 	"github.com/spf13/cobra"
 )
@@ -25,33 +26,36 @@ var rdeBlueprintStatusCmd = &cobra.Command{
 			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
-		utils.Println(fmt.Sprintf("Blueprint: %s", bp.ProjectName))
-		utils.Println(fmt.Sprintf("  Project:     %s", bp.ProjectId))
+		rows := [][]string{
+			{"Blueprint", pterm.FgBlue.Sprintf("%s", bp.ProjectName)},
+			{"Project", bp.ProjectId},
+		}
 
 		if bp.EnvId == "" {
-			utils.Println("  Environment: (none)")
+			rows = append(rows, []string{"Environment", "(none)"})
+			rdePrintKeyValueTable(rows)
 			return
 		}
 
-		utils.Println(fmt.Sprintf("  Environment: %s (%s)", bp.EnvName, bp.EnvId))
+		rows = append(rows, []string{"Environment", fmt.Sprintf("%s (%s)", bp.EnvName, bp.EnvId)})
 
 		status, err := rdeGetEnvStatus(client, bp.EnvId)
 		if err == nil {
-			utils.Println(fmt.Sprintf("  Status:      %s", utils.GetStatusTextWithColor(status)))
+			rows = append(rows, []string{"Status", utils.GetStatusTextWithColor(status)})
 		}
 
-		utils.Println(fmt.Sprintf("  Console:     https://console.qovery.com/organization/%s/project/%s/environment/%s", orgId, bp.ProjectId, bp.EnvId))
+		rows = append(rows, []string{"Console", fmt.Sprintf("https://console.qovery.com/organization/%s/project/%s/environment/%s", orgId, bp.ProjectId, bp.EnvId)})
 
 		// Count children
 		children, err := rdeListChildren(client, orgId, bp.ProjectId)
 		if err == nil {
-			utils.Println(fmt.Sprintf("  Children:    %d RDE(s)", len(children)))
+			rows = append(rows, []string{"Children", fmt.Sprintf("%d RDE(s)", len(children))})
 		}
+
+		rdePrintKeyValueTable(rows)
 
 		// List services
 		utils.Println("")
-		utils.Println("  Services:")
-
 		rdePrintEnvServices(client, bp.EnvId)
 	},
 }

--- a/cmd/rde_blueprint_stop.go
+++ b/cmd/rde_blueprint_stop.go
@@ -1,0 +1,61 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/qovery/qovery-cli/utils"
+	"github.com/qovery/qovery-client-go"
+	"github.com/spf13/cobra"
+)
+
+var rdeBlueprintStopCmd = &cobra.Command{
+	Use:   "stop",
+	Short: "Stop a blueprint environment",
+	Run: func(cmd *cobra.Command, args []string) {
+		utils.Capture(cmd)
+
+		client := utils.GetQoveryClientPanicInCaseOfError()
+		orgId, err := rdeGetOrgId(client)
+		checkError(err)
+
+		bp, err := rdeFindBlueprintByProjectName(client, orgId, rdeBlueprintProjectName)
+		if err != nil {
+			utils.PrintlnError(err)
+			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
+		}
+
+		if bp.EnvId == "" {
+			utils.PrintlnError(fmt.Errorf("blueprint %s has no environment with %s set", bp.ProjectName, rdeBlueprintKeyVar))
+			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
+		}
+
+		utils.Println(fmt.Sprintf("Stopping blueprint %s...", bp.ProjectName))
+		_, _, err = client.EnvironmentActionsAPI.StopEnvironment(context.Background(), bp.EnvId).Execute()
+		if err != nil {
+			utils.PrintlnError(fmt.Errorf("stop failed: %w", err))
+			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
+		}
+
+		utils.Println("Blueprint stop triggered.")
+
+		if watchFlag {
+			time.Sleep(3 * time.Second)
+			utils.WatchEnvironment(bp.EnvId, qovery.STATEENUM_STOPPED, client)
+		}
+	},
+}
+
+func init() {
+	rdeBlueprintCmd.AddCommand(rdeBlueprintStopCmd)
+	rdeBlueprintStopCmd.Flags().StringVarP(&rdeBlueprintProjectName, "project", "p", "", "Blueprint Project Name")
+	rdeBlueprintStopCmd.Flags().StringVarP(&organizationName, "organization", "o", "", "Organization Name")
+	rdeBlueprintStopCmd.Flags().BoolVarP(&watchFlag, "watch", "w", false, "Watch stop status until it completes or an error occurs")
+
+	_ = rdeBlueprintStopCmd.MarkFlagRequired("project")
+}

--- a/cmd/rde_blueprint_stop.go
+++ b/cmd/rde_blueprint_stop.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/pterm/pterm"
 	"github.com/qovery/qovery-cli/utils"
 	"github.com/qovery/qovery-client-go"
 	"github.com/spf13/cobra"
@@ -34,7 +35,6 @@ var rdeBlueprintStopCmd = &cobra.Command{
 			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
-		utils.Println(fmt.Sprintf("Stopping blueprint %s...", bp.ProjectName))
 		_, _, err = client.EnvironmentActionsAPI.StopEnvironment(context.Background(), bp.EnvId).Execute()
 		if err != nil {
 			utils.PrintlnError(fmt.Errorf("stop failed: %w", err))
@@ -42,7 +42,7 @@ var rdeBlueprintStopCmd = &cobra.Command{
 			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
-		utils.Println("Blueprint stop triggered.")
+		utils.Println(fmt.Sprintf("Request to stop blueprint %s has been queued..", pterm.FgBlue.Sprintf("%s", bp.ProjectName)))
 
 		if watchFlag {
 			time.Sleep(3 * time.Second)

--- a/cmd/rde_blueprint_unregister.go
+++ b/cmd/rde_blueprint_unregister.go
@@ -8,8 +8,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var rdeBlueprintDeleteCmd = &cobra.Command{
-	Use:   "delete",
+var rdeBlueprintUnregisterCmd = &cobra.Command{
+	Use:   "unregister",
 	Short: "Unregister a project as an RDE blueprint",
 	Long: `Remove the BLUEPRINT_PROJECT_ID and BLUEPRINT_KEY environment variables
 from the project and its environment. This does NOT delete the project itself.`,
@@ -61,9 +61,9 @@ from the project and its environment. This does NOT delete the project itself.`,
 }
 
 func init() {
-	rdeBlueprintCmd.AddCommand(rdeBlueprintDeleteCmd)
-	rdeBlueprintDeleteCmd.Flags().StringVarP(&rdeBlueprintProjectName, "project", "p", "", "Blueprint Project Name to unregister")
-	rdeBlueprintDeleteCmd.Flags().StringVarP(&organizationName, "organization", "o", "", "Organization Name")
+	rdeBlueprintCmd.AddCommand(rdeBlueprintUnregisterCmd)
+	rdeBlueprintUnregisterCmd.Flags().StringVarP(&rdeBlueprintProjectName, "project", "p", "", "Blueprint Project Name to unregister")
+	rdeBlueprintUnregisterCmd.Flags().StringVarP(&organizationName, "organization", "o", "", "Organization Name")
 
-	_ = rdeBlueprintDeleteCmd.MarkFlagRequired("project")
+	_ = rdeBlueprintUnregisterCmd.MarkFlagRequired("project")
 }

--- a/cmd/rde_create.go
+++ b/cmd/rde_create.go
@@ -1,0 +1,323 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/qovery/qovery-cli/utils"
+	"github.com/qovery/qovery-client-go"
+	"github.com/spf13/cobra"
+)
+
+var rdeCreateCmd = &cobra.Command{
+	Use:   "create",
+	Short: "Provision a new Remote Development Environment from a blueprint",
+	Long: `Create a new RDE by cloning a blueprint environment into a new project.
+
+This command:
+  1. Creates a new project for the RDE
+  2. Creates an RBAC role with scoped permissions (unless --skip-rbac)
+  3. Clones the blueprint environment into the new project
+  4. Updates the TTL job to target the new environment (if present)
+  5. Invites the developer via email (unless --skip-invite)
+  6. Triggers deployment (unless --skip-deploy)`,
+	Run: func(cmd *cobra.Command, args []string) {
+		utils.Capture(cmd)
+
+		client := utils.GetQoveryClientPanicInCaseOfError()
+		orgId, err := rdeGetOrgId(client)
+		checkError(err)
+
+		// Validate required flags
+		if rdeBlueprintProjectName == "" {
+			utils.PrintlnError(fmt.Errorf("--blueprint is required"))
+			os.Exit(1)
+			panic("unreachable")
+		}
+		if rdeName == "" {
+			utils.PrintlnError(fmt.Errorf("--name is required"))
+			os.Exit(1)
+			panic("unreachable")
+		}
+		if rdeEmail == "" && !rdeSkipInvite {
+			utils.PrintlnInfo("No --email provided, skipping member invitation (use --skip-invite to suppress this message)")
+			rdeSkipInvite = true
+		}
+
+		// Step 1: Resolve blueprint
+		utils.Println(fmt.Sprintf("Resolving blueprint %s...", rdeBlueprintProjectName))
+		bp, err := rdeFindBlueprintByProjectName(client, orgId, rdeBlueprintProjectName)
+		if err != nil {
+			utils.PrintlnError(err)
+			os.Exit(1)
+			panic("unreachable")
+		}
+		if bp.EnvId == "" {
+			utils.PrintlnError(fmt.Errorf("blueprint %s has no environment with %s set", bp.ProjectName, rdeBlueprintKeyVar))
+			os.Exit(1)
+			panic("unreachable")
+		}
+		utils.Println(fmt.Sprintf("  Blueprint: %s (env: %s)", bp.ProjectName, bp.EnvId))
+
+		// Step 2: Create project
+		projectName := fmt.Sprintf("rde-%s", rdeName)
+		utils.Println(fmt.Sprintf("\nStep 1/6: Creating project %s...", projectName))
+		desc := fmt.Sprintf("RDE for %s (blueprint: %s)", rdeName, bp.ProjectName)
+		projectReq := qovery.NewProjectRequest(projectName)
+		projectReq.Description = &desc
+		project, _, err := client.ProjectsAPI.CreateProject(ctx(), orgId).ProjectRequest(*projectReq).Execute()
+		if err != nil {
+			// Check if project already exists
+			existing, findErr := rdeFindProjectByName(client, orgId, projectName)
+			if findErr == nil && existing != nil {
+				utils.PrintlnInfo(fmt.Sprintf("Project %s already exists, reusing...", projectName))
+				project = existing
+			} else {
+				utils.PrintlnError(fmt.Errorf("failed to create project: %w", err))
+				os.Exit(1)
+				panic("unreachable")
+			}
+		}
+		utils.Println(fmt.Sprintf("  Project: %s", project.Id))
+
+		// Step 3: Create RBAC role
+		var roleId string
+		if !rdeSkipRbac {
+			roleName := fmt.Sprintf("RDE-%s", rdeName)
+			utils.Println(fmt.Sprintf("\nStep 2/6: Creating RBAC role %s...", roleName))
+
+			roleReq := qovery.NewOrganizationCustomRoleCreateRequest(roleName)
+			roleDesc := fmt.Sprintf("Access to %s only", projectName)
+			roleReq.Description = &roleDesc
+			role, _, err := client.OrganizationCustomRoleAPI.CreateOrganizationCustomRole(ctx(), orgId).
+				OrganizationCustomRoleCreateRequest(*roleReq).Execute()
+			if err != nil {
+				// Check if role already exists
+				existingRole, _ := rdeFindCustomRoleByName(client, orgId, roleName)
+				if existingRole != nil && existingRole.Id != nil {
+					utils.PrintlnInfo(fmt.Sprintf("Role %s already exists, reusing...", roleName))
+					roleId = *existingRole.Id
+				} else {
+					utils.PrintlnError(fmt.Errorf("failed to create RBAC role: %w", err))
+					utils.PrintlnInfo("Continuing without RBAC role (use --skip-rbac to suppress)")
+				}
+			} else if role.Id != nil {
+				roleId = *role.Id
+			}
+
+			if roleId != "" {
+				// Set permissions: all clusters VIEWER except target = ENV_CREATOR, all projects NO_ACCESS except ours = DEPLOYER
+				err = rdeSetRolePermissions(client, orgId, roleId, roleName, project.Id)
+				if err != nil {
+					utils.PrintlnError(fmt.Errorf("failed to set role permissions: %w", err))
+					utils.PrintlnInfo("RBAC role created but permissions may be incomplete")
+				}
+				utils.Println(fmt.Sprintf("  Role: %s", roleId))
+			}
+		} else {
+			utils.Println("\nStep 2/6: Skipping RBAC role creation (--skip-rbac)")
+		}
+
+		// Step 4: Clone blueprint
+		utils.Println("\nStep 3/6: Cloning blueprint environment...")
+		cloneReq := qovery.CloneEnvironmentRequest{
+			Name:      "workspace",
+			ProjectId: &project.Id,
+			Mode:      qovery.ENVIRONMENTMODEENUM_DEVELOPMENT.Ptr(),
+		}
+
+		// Optionally set cluster
+		if clusterName != "" {
+			clusters, _, err := client.ClustersAPI.ListOrganizationCluster(ctx(), orgId).Execute()
+			if err == nil {
+				for _, c := range clusters.GetResults() {
+					if strings.EqualFold(c.Name, clusterName) {
+						clId := c.Id
+						cloneReq.ClusterId = &clId
+						break
+					}
+				}
+			}
+		}
+
+		clonedEnv, _, err := client.EnvironmentActionsAPI.CloneEnvironment(ctx(), bp.EnvId).
+			CloneEnvironmentRequest(cloneReq).Execute()
+		if err != nil {
+			// Check if environment already exists
+			envInfo, findErr := rdeFindBlueprintEnv(client, project.Id)
+			if findErr == nil && envInfo != nil {
+				utils.PrintlnInfo("Environment already exists, reusing...")
+				// Create a minimal environment struct for use below
+				clonedEnv = &qovery.Environment{}
+				clonedEnv.Id = envInfo.EnvId
+				clonedEnv.Name = envInfo.EnvName
+			} else {
+				utils.PrintlnError(fmt.Errorf("failed to clone blueprint: %w", err))
+				os.Exit(1)
+				panic("unreachable")
+			}
+		}
+		utils.Println(fmt.Sprintf("  Environment: %s", clonedEnv.Id))
+
+		// Step 5: Update TTL job (if present)
+		utils.Println("\nStep 4/6: Checking for TTL job...")
+		rdeUpdateTTLJob(client, clonedEnv.Id)
+
+		// Step 6: Invite member
+		if !rdeSkipInvite && rdeEmail != "" {
+			utils.Println(fmt.Sprintf("\nStep 5/6: Inviting %s...", rdeEmail))
+			inviteReq := qovery.NewInviteMemberRequest(rdeEmail)
+			if roleId != "" {
+				inviteReq.RoleId = &roleId
+			}
+			_, _, err = client.MembersAPI.PostInviteMember(ctx(), orgId).
+				InviteMemberRequest(*inviteReq).Execute()
+			if err != nil {
+				utils.PrintlnInfo(fmt.Sprintf("Invitation failed or already sent: %v", err))
+			} else {
+				utils.Println(fmt.Sprintf("  Invited: %s", rdeEmail))
+			}
+		} else {
+			utils.Println("\nStep 5/6: Skipping invitation")
+		}
+
+		// Step 7: Deploy
+		if !rdeSkipDeploy {
+			utils.Println("\nStep 6/6: Deploying...")
+			_, _, err = client.EnvironmentActionsAPI.DeployEnvironment(ctx(), clonedEnv.Id).Execute()
+			if err != nil {
+				utils.PrintlnInfo(fmt.Sprintf("Deploy failed: %v (deploy from Console)", err))
+			} else {
+				utils.Println("  Deployment triggered")
+			}
+		} else {
+			utils.Println("\nStep 6/6: Skipping deployment (--skip-deploy)")
+		}
+
+		utils.Println("")
+		utils.Println(fmt.Sprintf("Done! RDE: %s", rdeName))
+		utils.Println(fmt.Sprintf("  Project:     %s", project.Id))
+		utils.Println(fmt.Sprintf("  Environment: %s", clonedEnv.Id))
+		utils.Println(fmt.Sprintf("  Console:     https://console.qovery.com/organization/%s/project/%s/environment/%s", orgId, project.Id, clonedEnv.Id))
+		utils.Println("  Workspace URL available once deployment completes.")
+	},
+}
+
+// rdeSetRolePermissions configures the RBAC role with appropriate cluster and project permissions.
+func rdeSetRolePermissions(client *qovery.APIClient, orgId string, roleId string, roleName string, targetProjectId string) error {
+	// Get all clusters
+	clusters, _, err := client.ClustersAPI.ListOrganizationCluster(ctx(), orgId).Execute()
+	if err != nil {
+		return fmt.Errorf("failed to list clusters: %w", err)
+	}
+
+	var clusterPerms []qovery.OrganizationCustomRoleUpdateRequestClusterPermissionsInner
+	for _, c := range clusters.GetResults() {
+		perm := qovery.ORGANIZATIONCUSTOMROLECLUSTERPERMISSION_VIEWER
+		// If cluster name matches, give ENV_CREATOR
+		if clusterName != "" && strings.EqualFold(c.Name, clusterName) {
+			perm = qovery.ORGANIZATIONCUSTOMROLECLUSTERPERMISSION_ENV_CREATOR
+		} else if clusterName == "" {
+			// If no cluster specified, give ENV_CREATOR on all clusters
+			perm = qovery.ORGANIZATIONCUSTOMROLECLUSTERPERMISSION_ENV_CREATOR
+		}
+		cId := c.Id
+		clusterPerms = append(clusterPerms, qovery.OrganizationCustomRoleUpdateRequestClusterPermissionsInner{
+			ClusterId:  &cId,
+			Permission: &perm,
+		})
+	}
+
+	// Get all projects
+	projects, _, err := client.ProjectsAPI.ListProject(ctx(), orgId).Execute()
+	if err != nil {
+		return fmt.Errorf("failed to list projects: %w", err)
+	}
+
+	var projectPerms []qovery.OrganizationCustomRoleUpdateRequestProjectPermissionsInner
+	for _, p := range projects.GetResults() {
+		isAdmin := false
+		pId := p.Id
+
+		var permissions []qovery.OrganizationCustomRoleUpdateRequestProjectPermissionsInnerPermissionsInner
+		if p.Id == targetProjectId {
+			// Target project: DEPLOYER for DEVELOPMENT and PREVIEW, VIEWER for STAGING, NO_ACCESS for PRODUCTION
+			devMode := qovery.ENVIRONMENTMODEENUM_DEVELOPMENT
+			stagingMode := qovery.ENVIRONMENTMODEENUM_STAGING
+			prodMode := qovery.ENVIRONMENTMODEENUM_PRODUCTION
+			deployerPerm := qovery.ORGANIZATIONCUSTOMROLEPROJECTPERMISSION_DEPLOYER
+			viewerPerm := qovery.ORGANIZATIONCUSTOMROLEPROJECTPERMISSION_VIEWER
+			noAccessPerm := qovery.ORGANIZATIONCUSTOMROLEPROJECTPERMISSION_NO_ACCESS
+
+			permissions = []qovery.OrganizationCustomRoleUpdateRequestProjectPermissionsInnerPermissionsInner{
+				{EnvironmentType: &devMode, Permission: &deployerPerm},
+				{EnvironmentType: &stagingMode, Permission: &viewerPerm},
+				{EnvironmentType: &prodMode, Permission: &noAccessPerm},
+			}
+		} else {
+			// Other projects: NO_ACCESS for all
+			devMode := qovery.ENVIRONMENTMODEENUM_DEVELOPMENT
+			stagingMode := qovery.ENVIRONMENTMODEENUM_STAGING
+			prodMode := qovery.ENVIRONMENTMODEENUM_PRODUCTION
+			noAccessPerm := qovery.ORGANIZATIONCUSTOMROLEPROJECTPERMISSION_NO_ACCESS
+
+			permissions = []qovery.OrganizationCustomRoleUpdateRequestProjectPermissionsInnerPermissionsInner{
+				{EnvironmentType: &devMode, Permission: &noAccessPerm},
+				{EnvironmentType: &stagingMode, Permission: &noAccessPerm},
+				{EnvironmentType: &prodMode, Permission: &noAccessPerm},
+			}
+		}
+
+		projectPerms = append(projectPerms, qovery.OrganizationCustomRoleUpdateRequestProjectPermissionsInner{
+			ProjectId:   &pId,
+			IsAdmin:     &isAdmin,
+			Permissions: permissions,
+		})
+	}
+
+	updateReq := qovery.NewOrganizationCustomRoleUpdateRequest(roleName, clusterPerms, projectPerms)
+	_, _, err = client.OrganizationCustomRoleAPI.EditOrganizationCustomRole(ctx(), orgId, roleId).
+		OrganizationCustomRoleUpdateRequest(*updateReq).Execute()
+	return err
+}
+
+// rdeUpdateTTLJob finds and updates the ttl-auto-shutdown job in the environment.
+func rdeUpdateTTLJob(client *qovery.APIClient, envId string) {
+	jobs, _, err := client.JobsAPI.ListJobs(ctx(), envId).Execute()
+	if err != nil {
+		utils.Println("  No jobs found (non-critical)")
+		return
+	}
+
+	for _, job := range jobs.GetResults() {
+		jobName := utils.GetJobName(&job)
+		if jobName == "ttl-auto-shutdown" {
+			jobId := utils.GetJobId(&job)
+			utils.Println(fmt.Sprintf("  Found TTL job: %s", jobId))
+			// The TTL job is cloned from the blueprint and may reference the blueprint env ID
+			// in its arguments. We don't modify the curl command here since the token would
+			// also need updating. The TTL job will work as-is if the SHUTDOWN_TOKEN env var
+			// is properly set on the job.
+			utils.Println("  TTL job preserved from blueprint clone")
+			return
+		}
+	}
+
+	utils.Println("  No TTL job found (non-critical)")
+}
+
+func init() {
+	rdeCmd.AddCommand(rdeCreateCmd)
+	rdeCreateCmd.Flags().StringVarP(&rdeBlueprintProjectName, "blueprint", "b", "", "Blueprint Project Name to clone from")
+	rdeCreateCmd.Flags().StringVarP(&rdeName, "name", "n", "", "Name for the new RDE (will create project rde-<name>)")
+	rdeCreateCmd.Flags().StringVarP(&rdeEmail, "email", "e", "", "Email address to invite the developer")
+	rdeCreateCmd.Flags().StringVarP(&clusterName, "cluster", "c", "", "Cluster Name where to create the RDE")
+	rdeCreateCmd.Flags().StringVarP(&organizationName, "organization", "o", "", "Organization Name")
+	rdeCreateCmd.Flags().BoolVarP(&rdeSkipRbac, "skip-rbac", "", false, "Skip RBAC role creation")
+	rdeCreateCmd.Flags().BoolVarP(&rdeSkipInvite, "skip-invite", "", false, "Skip member invitation")
+	rdeCreateCmd.Flags().BoolVarP(&rdeSkipDeploy, "skip-deploy", "", false, "Skip deployment after cloning")
+
+	_ = rdeCreateCmd.MarkFlagRequired("blueprint")
+	_ = rdeCreateCmd.MarkFlagRequired("name")
+}

--- a/cmd/rde_create.go
+++ b/cmd/rde_create.go
@@ -128,16 +128,36 @@ This command:
 			Mode:      qovery.ENVIRONMENTMODEENUM_DEVELOPMENT.Ptr(),
 		}
 
-		// Optionally set cluster
+		// Default to the blueprint's cluster
+		blueprintEnv, _, bpEnvErr := client.EnvironmentMainCallsAPI.GetEnvironment(ctx(), bp.EnvId).Execute()
+		if bpEnvErr == nil {
+			bpClusterId := blueprintEnv.ClusterId
+			cloneReq.ClusterId = &bpClusterId
+			clusterDisplay := bpClusterId
+			if blueprintEnv.ClusterName != nil {
+				clusterDisplay = *blueprintEnv.ClusterName
+			}
+			utils.Println(fmt.Sprintf("  Using blueprint cluster: %s", pterm.FgBlue.Sprintf("%s", clusterDisplay)))
+		}
+
+		// Override with --cluster flag if provided
 		if clusterName != "" {
-			clusters, _, err := client.ClustersAPI.ListOrganizationCluster(ctx(), orgId).Execute()
-			if err == nil {
+			clusters, _, clErr := client.ClustersAPI.ListOrganizationCluster(ctx(), orgId).Execute()
+			if clErr == nil {
+				found := false
 				for _, c := range clusters.GetResults() {
 					if strings.EqualFold(c.Name, clusterName) {
 						clId := c.Id
 						cloneReq.ClusterId = &clId
+						utils.Println(fmt.Sprintf("  Overriding cluster to: %s", pterm.FgBlue.Sprintf("%s", clusterName)))
+						found = true
 						break
 					}
+				}
+				if !found {
+					utils.PrintlnError(fmt.Errorf("cluster %s not found", clusterName))
+					os.Exit(1)
+					panic("unreachable")
 				}
 			}
 		}

--- a/cmd/rde_create.go
+++ b/cmd/rde_create.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/pterm/pterm"
 	"github.com/qovery/qovery-cli/utils"
 	"github.com/qovery/qovery-client-go"
 	"github.com/spf13/cobra"
@@ -46,7 +47,7 @@ This command:
 		}
 
 		// Step 1: Resolve blueprint
-		utils.Println(fmt.Sprintf("Resolving blueprint %s...", rdeBlueprintProjectName))
+		utils.Println(fmt.Sprintf("Resolving blueprint %s...", pterm.FgBlue.Sprintf("%s", rdeBlueprintProjectName)))
 		bp, err := rdeFindBlueprintByProjectName(client, orgId, rdeBlueprintProjectName)
 		if err != nil {
 			utils.PrintlnError(err)
@@ -62,7 +63,7 @@ This command:
 
 		// Step 2: Create project
 		projectName := fmt.Sprintf("rde-%s", rdeName)
-		utils.Println(fmt.Sprintf("\nStep 1/6: Creating project %s...", projectName))
+		utils.Println(fmt.Sprintf("\nStep 1/6: Creating project %s...", pterm.FgBlue.Sprintf("%s", projectName)))
 		desc := fmt.Sprintf("RDE for %s (blueprint: %s)", rdeName, bp.ProjectName)
 		projectReq := qovery.NewProjectRequest(projectName)
 		projectReq.Description = &desc
@@ -85,7 +86,7 @@ This command:
 		var roleId string
 		if !rdeSkipRbac {
 			roleName := fmt.Sprintf("RDE-%s", rdeName)
-			utils.Println(fmt.Sprintf("\nStep 2/6: Creating RBAC role %s...", roleName))
+			utils.Println(fmt.Sprintf("\nStep 2/6: Creating RBAC role %s...", pterm.FgBlue.Sprintf("%s", roleName)))
 
 			roleReq := qovery.NewOrganizationCustomRoleCreateRequest(roleName)
 			roleDesc := fmt.Sprintf("Access to %s only", projectName)
@@ -196,11 +197,15 @@ This command:
 		}
 
 		utils.Println("")
-		utils.Println(fmt.Sprintf("Done! RDE: %s", rdeName))
-		utils.Println(fmt.Sprintf("  Project:     %s", project.Id))
-		utils.Println(fmt.Sprintf("  Environment: %s", clonedEnv.Id))
-		utils.Println(fmt.Sprintf("  Console:     https://console.qovery.com/organization/%s/project/%s/environment/%s", orgId, project.Id, clonedEnv.Id))
-		utils.Println("  Workspace URL available once deployment completes.")
+		utils.Println(fmt.Sprintf("RDE %s provisioned successfully!", pterm.FgBlue.Sprintf("%s", rdeName)))
+		utils.Println("")
+		rdePrintKeyValueTable([][]string{
+			{"Project", project.Id},
+			{"Environment", clonedEnv.Id},
+			{"Console", fmt.Sprintf("https://console.qovery.com/organization/%s/project/%s/environment/%s", orgId, project.Id, clonedEnv.Id)},
+		})
+		utils.Println("")
+		utils.PrintlnInfo("Workspace URL will be available once deployment completes.")
 	},
 }
 

--- a/cmd/rde_create.go
+++ b/cmd/rde_create.go
@@ -181,6 +181,11 @@ This command:
 		}
 		utils.Println(fmt.Sprintf("  Environment: %s", clonedEnv.Id))
 
+		// Set RDE_OWNER_EMAIL on the cloned environment if email was provided
+		if rdeEmail != "" {
+			_ = utils.CreateEnvironmentVariable(client, project.Id, clonedEnv.Id, rdeOwnerEmailVar, rdeEmail, false)
+		}
+
 		// Step 5: Update TTL job (if present)
 		utils.Println("\nStep 4/6: Checking for TTL job...")
 		rdeUpdateTTLJob(client, clonedEnv.Id)

--- a/cmd/rde_delete.go
+++ b/cmd/rde_delete.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/pterm/pterm"
 	"github.com/qovery/qovery-cli/utils"
 	"github.com/qovery/qovery-client-go"
 	"github.com/spf13/cobra"
@@ -27,7 +28,7 @@ var rdeDeleteCmd = &cobra.Command{
 		checkError(err)
 
 		projectName := fmt.Sprintf("rde-%s", rdeName)
-		utils.Println(fmt.Sprintf("Deleting RDE: %s", rdeName))
+		utils.Println(fmt.Sprintf("Deleting RDE %s...", pterm.FgBlue.Sprintf("%s", rdeName)))
 
 		// Find the project
 		project, err := rdeFindProjectByName(client, orgId, projectName)
@@ -46,13 +47,13 @@ var rdeDeleteCmd = &cobra.Command{
 				// Stop environment
 				status, _ := rdeGetEnvStatus(client, env.Id)
 				if status != qovery.STATEENUM_STOPPED && status != "" {
-					utils.Println(fmt.Sprintf("  Stopping environment %s...", env.Name))
+					utils.Println(fmt.Sprintf("  Stopping environment %s...", pterm.FgBlue.Sprintf("%s", env.Name)))
 					_, _, _ = client.EnvironmentActionsAPI.StopEnvironment(ctx(), env.Id).Execute()
 					time.Sleep(2 * time.Second)
 				}
 
 				// Delete environment
-				utils.Println(fmt.Sprintf("  Deleting environment %s...", env.Name))
+				utils.Println(fmt.Sprintf("  Deleting environment %s...", pterm.FgBlue.Sprintf("%s", env.Name)))
 				_, err = client.EnvironmentMainCallsAPI.DeleteEnvironment(ctx(), env.Id).Execute()
 				if err != nil {
 					utils.PrintlnInfo(fmt.Sprintf("Failed to delete environment: %v", err))
@@ -61,7 +62,7 @@ var rdeDeleteCmd = &cobra.Command{
 		}
 
 		// Delete project
-		utils.Println(fmt.Sprintf("  Deleting project %s...", projectName))
+		utils.Println(fmt.Sprintf("  Deleting project %s...", pterm.FgBlue.Sprintf("%s", projectName)))
 		_, err = client.ProjectMainCallsAPI.DeleteProject(ctx(), project.Id).Execute()
 		if err != nil {
 			utils.PrintlnInfo(fmt.Sprintf("Failed to delete project: %v", err))
@@ -70,8 +71,7 @@ var rdeDeleteCmd = &cobra.Command{
 		// Cleanup role and token
 		rdeCleanupRoleAndToken(client, orgId, rdeName)
 
-		utils.Println("")
-		utils.Println(fmt.Sprintf("RDE %s fully removed.", rdeName))
+		utils.Println(fmt.Sprintf("\nRDE %s fully removed.", pterm.FgBlue.Sprintf("%s", rdeName)))
 	},
 }
 
@@ -81,7 +81,7 @@ func rdeCleanupRoleAndToken(client *qovery.APIClient, orgId string, name string)
 	roleName := fmt.Sprintf("RDE-%s", name)
 	role, _ := rdeFindCustomRoleByName(client, orgId, roleName)
 	if role != nil && role.Id != nil {
-		utils.Println(fmt.Sprintf("  Deleting role %s...", roleName))
+		utils.Println(fmt.Sprintf("  Deleting role %s...", pterm.FgBlue.Sprintf("%s", roleName)))
 		_, _ = client.OrganizationCustomRoleAPI.DeleteOrganizationCustomRole(ctx(), orgId, *role.Id).Execute()
 	}
 
@@ -92,7 +92,7 @@ func rdeCleanupRoleAndToken(client *qovery.APIClient, orgId string, name string)
 		for _, token := range tokens.GetResults() {
 			if token.Name != nil && *token.Name == tokenName {
 				if token.Id != "" {
-					utils.Println(fmt.Sprintf("  Deleting API token %s...", tokenName))
+					utils.Println(fmt.Sprintf("  Deleting API token %s...", pterm.FgBlue.Sprintf("%s", tokenName)))
 					_, _ = client.OrganizationApiTokenAPI.DeleteOrganizationApiToken(ctx(), orgId, token.Id).Execute()
 				}
 				break

--- a/cmd/rde_delete.go
+++ b/cmd/rde_delete.go
@@ -1,0 +1,111 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/qovery/qovery-cli/utils"
+	"github.com/qovery/qovery-client-go"
+	"github.com/spf13/cobra"
+)
+
+var rdeDeleteCmd = &cobra.Command{
+	Use:   "delete",
+	Short: "Delete an RDE (environment, project, RBAC role, and API token)",
+	Long: `Fully remove an RDE by:
+  1. Stopping the environment (if running)
+  2. Deleting the environment
+  3. Deleting the project
+  4. Deleting the RBAC role RDE-<name> (if exists)
+  5. Deleting the API token ttl-<name> (if exists)`,
+	Run: func(cmd *cobra.Command, args []string) {
+		utils.Capture(cmd)
+
+		client := utils.GetQoveryClientPanicInCaseOfError()
+		orgId, err := rdeGetOrgId(client)
+		checkError(err)
+
+		projectName := fmt.Sprintf("rde-%s", rdeName)
+		utils.Println(fmt.Sprintf("Deleting RDE: %s", rdeName))
+
+		// Find the project
+		project, err := rdeFindProjectByName(client, orgId, projectName)
+		if err != nil {
+			utils.PrintlnError(fmt.Errorf("RDE %s not found (no project %s)", rdeName, projectName))
+			// Still try to clean up role and token
+			rdeCleanupRoleAndToken(client, orgId, rdeName)
+			os.Exit(1)
+			panic("unreachable")
+		}
+
+		// Find environment
+		environments, _, err := client.EnvironmentsAPI.ListEnvironment(ctx(), project.Id).Execute()
+		if err == nil {
+			for _, env := range environments.GetResults() {
+				// Stop environment
+				status, _ := rdeGetEnvStatus(client, env.Id)
+				if status != qovery.STATEENUM_STOPPED && status != "" {
+					utils.Println(fmt.Sprintf("  Stopping environment %s...", env.Name))
+					_, _, _ = client.EnvironmentActionsAPI.StopEnvironment(ctx(), env.Id).Execute()
+					time.Sleep(2 * time.Second)
+				}
+
+				// Delete environment
+				utils.Println(fmt.Sprintf("  Deleting environment %s...", env.Name))
+				_, err = client.EnvironmentMainCallsAPI.DeleteEnvironment(ctx(), env.Id).Execute()
+				if err != nil {
+					utils.PrintlnInfo(fmt.Sprintf("Failed to delete environment: %v", err))
+				}
+			}
+		}
+
+		// Delete project
+		utils.Println(fmt.Sprintf("  Deleting project %s...", projectName))
+		_, err = client.ProjectMainCallsAPI.DeleteProject(ctx(), project.Id).Execute()
+		if err != nil {
+			utils.PrintlnInfo(fmt.Sprintf("Failed to delete project: %v", err))
+		}
+
+		// Cleanup role and token
+		rdeCleanupRoleAndToken(client, orgId, rdeName)
+
+		utils.Println("")
+		utils.Println(fmt.Sprintf("RDE %s fully removed.", rdeName))
+	},
+}
+
+// rdeCleanupRoleAndToken removes the RBAC role and API token associated with an RDE.
+func rdeCleanupRoleAndToken(client *qovery.APIClient, orgId string, name string) {
+	// Delete RBAC role
+	roleName := fmt.Sprintf("RDE-%s", name)
+	role, _ := rdeFindCustomRoleByName(client, orgId, roleName)
+	if role != nil && role.Id != nil {
+		utils.Println(fmt.Sprintf("  Deleting role %s...", roleName))
+		_, _ = client.OrganizationCustomRoleAPI.DeleteOrganizationCustomRole(ctx(), orgId, *role.Id).Execute()
+	}
+
+	// Delete API token
+	tokenName := fmt.Sprintf("ttl-%s", name)
+	tokens, _, err := client.OrganizationApiTokenAPI.ListOrganizationApiTokens(ctx(), orgId).Execute()
+	if err == nil {
+		for _, token := range tokens.GetResults() {
+			if token.Name != nil && *token.Name == tokenName {
+				if token.Id != "" {
+					utils.Println(fmt.Sprintf("  Deleting API token %s...", tokenName))
+					_, _ = client.OrganizationApiTokenAPI.DeleteOrganizationApiToken(ctx(), orgId, token.Id).Execute()
+				}
+				break
+			}
+		}
+	}
+}
+
+func init() {
+	rdeCmd.AddCommand(rdeDeleteCmd)
+	rdeDeleteCmd.Flags().StringVarP(&rdeName, "name", "n", "", "RDE Name")
+	rdeDeleteCmd.Flags().StringVarP(&organizationName, "organization", "o", "", "Organization Name")
+	rdeDeleteCmd.Flags().BoolVarP(&watchFlag, "watch", "w", false, "Watch deletion status")
+
+	_ = rdeDeleteCmd.MarkFlagRequired("name")
+}

--- a/cmd/rde_delete_all.go
+++ b/cmd/rde_delete_all.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/pterm/pterm"
 	"github.com/qovery/qovery-cli/utils"
 	"github.com/qovery/qovery-client-go"
 	"github.com/spf13/cobra"
@@ -59,7 +60,7 @@ This will delete the environment, project, RBAC role, and API token for each RDE
 			// Extract the RDE name from project name (strip "rde-" prefix if present)
 			name := strings.TrimPrefix(child.ProjectName, "rde-")
 
-			utils.Println(fmt.Sprintf("=== Deleting: %s ===", child.ProjectName))
+			utils.Println(fmt.Sprintf("=== Deleting: %s ===", pterm.FgBlue.Sprintf("%s", child.ProjectName)))
 
 			// Stop environment
 			if child.EnvId != "" {

--- a/cmd/rde_delete_all.go
+++ b/cmd/rde_delete_all.go
@@ -57,10 +57,7 @@ This will delete the environment, project, RBAC role, and API token for each RDE
 
 		for _, child := range children {
 			// Extract the RDE name from project name (strip "rde-" prefix if present)
-			name := child.ProjectName
-			if strings.HasPrefix(name, "rde-") {
-				name = strings.TrimPrefix(name, "rde-")
-			}
+			name := strings.TrimPrefix(child.ProjectName, "rde-")
 
 			utils.Println(fmt.Sprintf("=== Deleting: %s ===", child.ProjectName))
 

--- a/cmd/rde_delete_all.go
+++ b/cmd/rde_delete_all.go
@@ -1,0 +1,99 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/qovery/qovery-cli/utils"
+	"github.com/qovery/qovery-client-go"
+	"github.com/spf13/cobra"
+)
+
+var rdeDeleteAllCmd = &cobra.Command{
+	Use:   "delete-all",
+	Short: "Delete ALL RDE environments",
+	Long: `Delete all RDE environments permanently. Requires --confirm flag.
+
+This will delete the environment, project, RBAC role, and API token for each RDE.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		utils.Capture(cmd)
+
+		if !rdeConfirmFlag {
+			utils.PrintlnError(fmt.Errorf("this will delete ALL RDE environments permanently"))
+			utils.Println("Run with --confirm to proceed: qovery rde delete-all --confirm")
+			os.Exit(1)
+			panic("unreachable")
+		}
+
+		client := utils.GetQoveryClientPanicInCaseOfError()
+		orgId, err := rdeGetOrgId(client)
+		checkError(err)
+
+		var children []rdeChildInfo
+
+		if rdeBlueprintProjectName != "" {
+			bp, err := rdeFindBlueprintByProjectName(client, orgId, rdeBlueprintProjectName)
+			if err != nil {
+				utils.PrintlnError(err)
+				os.Exit(1)
+				panic("unreachable")
+			}
+			children, err = rdeListChildren(client, orgId, bp.ProjectId)
+			checkError(err)
+		} else {
+			children, err = rdeListAllChildren(client, orgId)
+			checkError(err)
+		}
+
+		if len(children) == 0 {
+			utils.Println("No RDE instances found.")
+			return
+		}
+
+		utils.Println(fmt.Sprintf("Deleting %d RDE environment(s)...", len(children)))
+		utils.Println("")
+
+		for _, child := range children {
+			// Extract the RDE name from project name (strip "rde-" prefix if present)
+			name := child.ProjectName
+			if strings.HasPrefix(name, "rde-") {
+				name = strings.TrimPrefix(name, "rde-")
+			}
+
+			utils.Println(fmt.Sprintf("=== Deleting: %s ===", child.ProjectName))
+
+			// Stop environment
+			if child.EnvId != "" {
+				status, _ := rdeGetEnvStatus(client, child.EnvId)
+				if status != qovery.STATEENUM_STOPPED && status != "" {
+					utils.Println("  Stopping environment...")
+					_, _, _ = client.EnvironmentActionsAPI.StopEnvironment(ctx(), child.EnvId).Execute()
+					time.Sleep(2 * time.Second)
+				}
+
+				utils.Println("  Deleting environment...")
+				_, _ = client.EnvironmentMainCallsAPI.DeleteEnvironment(ctx(), child.EnvId).Execute()
+			}
+
+			// Delete project
+			utils.Println(fmt.Sprintf("  Deleting project %s...", child.ProjectName))
+			_, _ = client.ProjectMainCallsAPI.DeleteProject(ctx(), child.ProjectId).Execute()
+
+			// Cleanup role and token
+			rdeCleanupRoleAndToken(client, orgId, name)
+
+			utils.Println("")
+		}
+
+		utils.Println("All RDE environments deleted.")
+	},
+}
+
+func init() {
+	rdeCmd.AddCommand(rdeDeleteAllCmd)
+	rdeDeleteAllCmd.Flags().BoolVarP(&rdeConfirmFlag, "confirm", "", false, "Confirm deletion of all RDE environments")
+	rdeDeleteAllCmd.Flags().StringVarP(&rdeBlueprintProjectName, "blueprint", "b", "", "Filter by Blueprint Project Name")
+	rdeDeleteAllCmd.Flags().StringVarP(&organizationName, "organization", "o", "", "Organization Name")
+}

--- a/cmd/rde_info.go
+++ b/cmd/rde_info.go
@@ -46,10 +46,10 @@ var rdeInfoCmd = &cobra.Command{
 					errors++
 					continue
 				}
-				switch {
-				case status == qovery.STATEENUM_DEPLOYED || status == qovery.STATEENUM_RESTARTED:
+				switch status {
+				case qovery.STATEENUM_DEPLOYED, qovery.STATEENUM_RESTARTED:
 					running++
-				case status == qovery.STATEENUM_STOPPED:
+				case qovery.STATEENUM_STOPPED:
 					stopped++
 				default:
 					errors++

--- a/cmd/rde_info.go
+++ b/cmd/rde_info.go
@@ -57,29 +57,29 @@ var rdeInfoCmd = &cobra.Command{
 			}
 		}
 
-		utils.Println("")
-		utils.Println("Remote Development Environment Platform")
-		utils.Println(fmt.Sprintf("  Organization:  %s (%s)", orgName, orgId))
-		utils.Println("")
-		utils.Println(fmt.Sprintf("  Blueprints:    %d", len(blueprints)))
+		// Platform summary table
+		rdePrintKeyValueTable([][]string{
+			{"Organization", fmt.Sprintf("%s (%s)", orgName, orgId)},
+			{"Blueprints", fmt.Sprintf("%d", len(blueprints))},
+			{"RDEs", fmt.Sprintf("%d total (%d running, %d stopped, %d error/other)", len(allChildren), running, stopped, errors)},
+		})
+
+		// Blueprints detail table
 		if len(blueprints) > 0 {
+			utils.Println("")
+			var data [][]string
 			for _, bp := range blueprints {
 				status := "NO_ENV"
 				if bp.EnvId != "" {
 					s, err := rdeGetEnvStatus(client, bp.EnvId)
 					if err == nil {
-						status = string(s)
+						status = utils.GetStatusTextWithColor(s)
 					}
 				}
-				utils.Println(fmt.Sprintf("    - %s (%s)", bp.ProjectName, status))
+				data = append(data, []string{bp.ProjectName, bp.EnvName, status, bp.ProjectId})
 			}
+			_ = utils.PrintTable([]string{"Blueprint", "Environment", "Status", "Project ID"}, data)
 		}
-		utils.Println("")
-		utils.Println(fmt.Sprintf("  RDEs:          %d total", len(allChildren)))
-		utils.Println(fmt.Sprintf("    Running:     %d", running))
-		utils.Println(fmt.Sprintf("    Stopped:     %d", stopped))
-		utils.Println(fmt.Sprintf("    Error/Other: %d", errors))
-		utils.Println("")
 	},
 }
 

--- a/cmd/rde_info.go
+++ b/cmd/rde_info.go
@@ -1,0 +1,89 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/qovery/qovery-cli/utils"
+	"github.com/qovery/qovery-client-go"
+	"github.com/spf13/cobra"
+)
+
+var rdeInfoCmd = &cobra.Command{
+	Use:   "info",
+	Short: "Show RDE platform overview",
+	Run: func(cmd *cobra.Command, args []string) {
+		utils.Capture(cmd)
+
+		client := utils.GetQoveryClientPanicInCaseOfError()
+		orgId, err := rdeGetOrgId(client)
+		checkError(err)
+
+		// Get organization name
+		orgName := orgId
+		orgs, _, err := client.OrganizationMainCallsAPI.ListOrganization(ctx()).Execute()
+		if err == nil {
+			for _, org := range orgs.GetResults() {
+				if org.Id == orgId {
+					orgName = org.Name
+					break
+				}
+			}
+		}
+
+		// List blueprints
+		blueprints, _ := rdeListBlueprintProjects(client, orgId)
+
+		// List all children and count statuses
+		allChildren, _ := rdeListAllChildren(client, orgId)
+		running := 0
+		stopped := 0
+		errors := 0
+
+		for _, child := range allChildren {
+			if child.EnvId != "" {
+				status, err := rdeGetEnvStatus(client, child.EnvId)
+				if err != nil {
+					errors++
+					continue
+				}
+				switch {
+				case status == qovery.STATEENUM_DEPLOYED || status == qovery.STATEENUM_RESTARTED:
+					running++
+				case status == qovery.STATEENUM_STOPPED:
+					stopped++
+				default:
+					errors++
+				}
+			}
+		}
+
+		utils.Println("")
+		utils.Println("Remote Development Environment Platform")
+		utils.Println(fmt.Sprintf("  Organization:  %s (%s)", orgName, orgId))
+		utils.Println("")
+		utils.Println(fmt.Sprintf("  Blueprints:    %d", len(blueprints)))
+		if len(blueprints) > 0 {
+			for _, bp := range blueprints {
+				status := "NO_ENV"
+				if bp.EnvId != "" {
+					s, err := rdeGetEnvStatus(client, bp.EnvId)
+					if err == nil {
+						status = string(s)
+					}
+				}
+				utils.Println(fmt.Sprintf("    - %s (%s)", bp.ProjectName, status))
+			}
+		}
+		utils.Println("")
+		utils.Println(fmt.Sprintf("  RDEs:          %d total", len(allChildren)))
+		utils.Println(fmt.Sprintf("    Running:     %d", running))
+		utils.Println(fmt.Sprintf("    Stopped:     %d", stopped))
+		utils.Println(fmt.Sprintf("    Error/Other: %d", errors))
+		utils.Println("")
+	},
+}
+
+func init() {
+	rdeCmd.AddCommand(rdeInfoCmd)
+	rdeInfoCmd.Flags().StringVarP(&organizationName, "organization", "o", "", "Organization Name")
+}

--- a/cmd/rde_list.go
+++ b/cmd/rde_list.go
@@ -91,7 +91,8 @@ Shows name, blueprint, status, uptime, and workspace URL for each RDE.`,
 				s, err := rdeGetEnvStatus(client, child.EnvId)
 				if err == nil {
 					status = string(utils.GetStatusTextWithColor(s))
-					if s == qovery.STATEENUM_DEPLOYED || s == qovery.STATEENUM_RESTARTED {
+					switch s {
+					case qovery.STATEENUM_DEPLOYED, qovery.STATEENUM_RESTARTED:
 						running++
 						url = rdeGetWorkspaceUrl(client, child.EnvId)
 						if url == "" {
@@ -99,9 +100,9 @@ Shows name, blueprint, status, uptime, and workspace URL for each RDE.`,
 						}
 						lastDeploy := rdeGetLastDeployTime(client, child.EnvId)
 						uptime = rdeFormatUptime(lastDeploy)
-					} else if s == qovery.STATEENUM_STOPPED {
+					case qovery.STATEENUM_STOPPED:
 						stopped++
-					} else {
+					default:
 						errors++
 					}
 				} else {

--- a/cmd/rde_list.go
+++ b/cmd/rde_list.go
@@ -1,0 +1,133 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/qovery/qovery-cli/utils"
+	"github.com/qovery/qovery-client-go"
+	"github.com/spf13/cobra"
+)
+
+var rdeListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List all RDE instances",
+	Long: `List all Remote Development Environments, optionally filtered by blueprint.
+
+Shows name, blueprint, status, uptime, and workspace URL for each RDE.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		utils.Capture(cmd)
+
+		client := utils.GetQoveryClientPanicInCaseOfError()
+		orgId, err := rdeGetOrgId(client)
+		checkError(err)
+
+		var children []rdeChildInfo
+
+		if rdeBlueprintProjectName != "" {
+			// Filter by specific blueprint
+			bp, err := rdeFindBlueprintByProjectName(client, orgId, rdeBlueprintProjectName)
+			if err != nil {
+				utils.PrintlnError(err)
+				os.Exit(1)
+				panic("unreachable")
+			}
+			children, err = rdeListChildren(client, orgId, bp.ProjectId)
+			checkError(err)
+		} else {
+			// List all children across all blueprints
+			children, err = rdeListAllChildren(client, orgId)
+			checkError(err)
+		}
+
+		if len(children) == 0 {
+			utils.Println("No RDE instances found.")
+			return
+		}
+
+		if jsonFlag {
+			var results []interface{}
+			for _, child := range children {
+				status := ""
+				url := ""
+				if child.EnvId != "" {
+					s, err := rdeGetEnvStatus(client, child.EnvId)
+					if err == nil {
+						status = string(s)
+					}
+					if s == qovery.STATEENUM_DEPLOYED {
+						url = rdeGetWorkspaceUrl(client, child.EnvId)
+					}
+				}
+				bpName := rdeBlueprintNameForProjectId(client, child.BlueprintProjectId)
+				results = append(results, map[string]interface{}{
+					"project_id":     child.ProjectId,
+					"project_name":   child.ProjectName,
+					"env_id":         child.EnvId,
+					"env_name":       child.EnvName,
+					"blueprint_id":   child.BlueprintProjectId,
+					"blueprint_name": bpName,
+					"status":         status,
+					"workspace_url":  url,
+				})
+			}
+			j, _ := json.Marshal(results)
+			utils.Println(string(j))
+			return
+		}
+
+		running := 0
+		stopped := 0
+		errors := 0
+
+		var data [][]string
+		for _, child := range children {
+			status := "UNKNOWN"
+			uptime := "-"
+			url := "-"
+
+			if child.EnvId != "" {
+				s, err := rdeGetEnvStatus(client, child.EnvId)
+				if err == nil {
+					status = string(utils.GetStatusTextWithColor(s))
+					if s == qovery.STATEENUM_DEPLOYED || s == qovery.STATEENUM_RESTARTED {
+						running++
+						url = rdeGetWorkspaceUrl(client, child.EnvId)
+						if url == "" {
+							url = "-"
+						}
+						lastDeploy := rdeGetLastDeployTime(client, child.EnvId)
+						uptime = rdeFormatUptime(lastDeploy)
+					} else if s == qovery.STATEENUM_STOPPED {
+						stopped++
+					} else {
+						errors++
+					}
+				} else {
+					errors++
+				}
+			}
+
+			bpName := rdeBlueprintNameForProjectId(client, child.BlueprintProjectId)
+
+			data = append(data, []string{child.ProjectName, bpName, status, uptime, url})
+		}
+
+		err = utils.PrintTable([]string{"Name", "Blueprint", "Status", "Uptime", "Workspace URL"}, data)
+		if err != nil {
+			utils.PrintlnError(err)
+			os.Exit(1)
+			panic("unreachable")
+		}
+
+		utils.Println(fmt.Sprintf("\nTotal: %d RDE(s) (%d running, %d stopped, %d error/other)", len(children), running, stopped, errors))
+	},
+}
+
+func init() {
+	rdeCmd.AddCommand(rdeListCmd)
+	rdeListCmd.Flags().StringVarP(&rdeBlueprintProjectName, "blueprint", "b", "", "Filter by Blueprint Project Name")
+	rdeListCmd.Flags().StringVarP(&organizationName, "organization", "o", "", "Organization Name")
+	rdeListCmd.Flags().BoolVarP(&jsonFlag, "json", "", false, "JSON output")
+}

--- a/cmd/rde_list.go
+++ b/cmd/rde_list.go
@@ -69,6 +69,7 @@ Shows name, blueprint, status, uptime, and workspace URL for each RDE.`,
 					"blueprint_id":   child.BlueprintProjectId,
 					"blueprint_name": bpName,
 					"status":         status,
+					"owner":          child.OwnerEmail,
 					"workspace_url":  url,
 				})
 			}
@@ -111,11 +112,15 @@ Shows name, blueprint, status, uptime, and workspace URL for each RDE.`,
 			}
 
 			bpName := rdeBlueprintNameForProjectId(client, child.BlueprintProjectId)
+			owner := child.OwnerEmail
+			if owner == "" {
+				owner = "-"
+			}
 
-			data = append(data, []string{child.ProjectName, bpName, status, uptime, url})
+			data = append(data, []string{child.ProjectName, bpName, status, uptime, owner, url})
 		}
 
-		err = utils.PrintTable([]string{"Name", "Blueprint", "Status", "Uptime", "Workspace URL"}, data)
+		err = utils.PrintTable([]string{"Name", "Blueprint", "Status", "Uptime", "Owner", "Workspace URL"}, data)
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)

--- a/cmd/rde_logs.go
+++ b/cmd/rde_logs.go
@@ -1,0 +1,71 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/qovery/qovery-cli/utils"
+	"github.com/spf13/cobra"
+)
+
+var rdeLogsCmd = &cobra.Command{
+	Use:   "logs",
+	Short: "Fetch recent logs from an RDE workspace",
+	Run: func(cmd *cobra.Command, args []string) {
+		utils.Capture(cmd)
+
+		client := utils.GetQoveryClientPanicInCaseOfError()
+		orgId, err := rdeGetOrgId(client)
+		checkError(err)
+
+		child, err := rdeFindChildByName(client, orgId, fmt.Sprintf("rde-%s", rdeName))
+		if err != nil {
+			utils.PrintlnError(err)
+			os.Exit(1)
+			panic("unreachable")
+		}
+
+		// Find the first application in the environment
+		apps, _, err := client.ApplicationsAPI.ListApplication(ctx(), child.EnvId).Execute()
+		if err != nil || len(apps.GetResults()) == 0 {
+			utils.PrintlnError(fmt.Errorf("no applications found in RDE %s", rdeName))
+			os.Exit(1)
+			panic("unreachable")
+		}
+
+		appId := apps.GetResults()[0].Id
+		appName := apps.GetResults()[0].GetName()
+
+		utils.Println(fmt.Sprintf("Fetching logs for RDE %s (service: %s)...", rdeName, appName))
+		utils.Println("")
+
+		logs, _, err := client.ApplicationLogsAPI.ListApplicationLog(ctx(), appId).Execute()
+		if err != nil {
+			utils.PrintlnError(fmt.Errorf("failed to fetch logs: %w", err))
+			os.Exit(1)
+			panic("unreachable")
+		}
+
+		logResults := logs.GetResults()
+		// Show last 50 lines
+		start := 0
+		if len(logResults) > 50 {
+			start = len(logResults) - 50
+		}
+
+		for _, logEntry := range logResults[start:] {
+			msg := logEntry.GetMessage()
+			if msg != "" {
+				utils.Println(msg)
+			}
+		}
+	},
+}
+
+func init() {
+	rdeCmd.AddCommand(rdeLogsCmd)
+	rdeLogsCmd.Flags().StringVarP(&rdeName, "name", "n", "", "RDE Name")
+	rdeLogsCmd.Flags().StringVarP(&organizationName, "organization", "o", "", "Organization Name")
+
+	_ = rdeLogsCmd.MarkFlagRequired("name")
+}

--- a/cmd/rde_start.go
+++ b/cmd/rde_start.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/pterm/pterm"
 	"github.com/qovery/qovery-cli/utils"
 	"github.com/qovery/qovery-client-go"
 	"github.com/spf13/cobra"
@@ -27,7 +28,6 @@ var rdeStartCmd = &cobra.Command{
 			panic("unreachable")
 		}
 
-		utils.Println(fmt.Sprintf("Starting RDE %s...", rdeName))
 		_, _, err = client.EnvironmentActionsAPI.DeployEnvironment(ctx(), child.EnvId).Execute()
 		if err != nil {
 			utils.PrintlnError(fmt.Errorf("deploy failed: %w", err))
@@ -35,7 +35,7 @@ var rdeStartCmd = &cobra.Command{
 			panic("unreachable")
 		}
 
-		utils.Println("  Deploy triggered.")
+		utils.Println(fmt.Sprintf("Request to start RDE %s has been queued..", pterm.FgBlue.Sprintf("%s", rdeName)))
 
 		if watchFlag {
 			time.Sleep(3 * time.Second)

--- a/cmd/rde_start.go
+++ b/cmd/rde_start.go
@@ -1,0 +1,54 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/qovery/qovery-cli/utils"
+	"github.com/qovery/qovery-client-go"
+	"github.com/spf13/cobra"
+)
+
+var rdeStartCmd = &cobra.Command{
+	Use:   "start",
+	Short: "Start (deploy) an RDE",
+	Run: func(cmd *cobra.Command, args []string) {
+		utils.Capture(cmd)
+
+		client := utils.GetQoveryClientPanicInCaseOfError()
+		orgId, err := rdeGetOrgId(client)
+		checkError(err)
+
+		child, err := rdeFindChildByName(client, orgId, fmt.Sprintf("rde-%s", rdeName))
+		if err != nil {
+			utils.PrintlnError(err)
+			os.Exit(1)
+			panic("unreachable")
+		}
+
+		utils.Println(fmt.Sprintf("Starting RDE %s...", rdeName))
+		_, _, err = client.EnvironmentActionsAPI.DeployEnvironment(ctx(), child.EnvId).Execute()
+		if err != nil {
+			utils.PrintlnError(fmt.Errorf("deploy failed: %w", err))
+			os.Exit(1)
+			panic("unreachable")
+		}
+
+		utils.Println("  Deploy triggered.")
+
+		if watchFlag {
+			time.Sleep(3 * time.Second)
+			utils.WatchEnvironment(child.EnvId, qovery.STATEENUM_DEPLOYED, client)
+		}
+	},
+}
+
+func init() {
+	rdeCmd.AddCommand(rdeStartCmd)
+	rdeStartCmd.Flags().StringVarP(&rdeName, "name", "n", "", "RDE Name")
+	rdeStartCmd.Flags().StringVarP(&organizationName, "organization", "o", "", "Organization Name")
+	rdeStartCmd.Flags().BoolVarP(&watchFlag, "watch", "w", false, "Watch deployment status until it's ready or an error occurs")
+
+	_ = rdeStartCmd.MarkFlagRequired("name")
+}

--- a/cmd/rde_start_all.go
+++ b/cmd/rde_start_all.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/pterm/pterm"
 	"github.com/qovery/qovery-cli/utils"
 	"github.com/spf13/cobra"
 )
@@ -44,9 +45,9 @@ var rdeStartAllCmd = &cobra.Command{
 			if child.EnvId != "" {
 				_, _, err := client.EnvironmentActionsAPI.DeployEnvironment(ctx(), child.EnvId).Execute()
 				if err != nil {
-					utils.Println(fmt.Sprintf("  Failed to start: %s (%v)", child.ProjectName, err))
+					utils.Println(fmt.Sprintf("  Failed to start: %s (%v)", pterm.FgBlue.Sprintf("%s", child.ProjectName), err))
 				} else {
-					utils.Println(fmt.Sprintf("  Started: %s", child.ProjectName))
+					utils.Println(fmt.Sprintf("  Request to start %s has been queued..", pterm.FgBlue.Sprintf("%s", child.ProjectName)))
 				}
 			}
 		}

--- a/cmd/rde_start_all.go
+++ b/cmd/rde_start_all.go
@@ -1,0 +1,61 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/qovery/qovery-cli/utils"
+	"github.com/spf13/cobra"
+)
+
+var rdeStartAllCmd = &cobra.Command{
+	Use:   "start-all",
+	Short: "Start (deploy) all RDE environments",
+	Run: func(cmd *cobra.Command, args []string) {
+		utils.Capture(cmd)
+
+		client := utils.GetQoveryClientPanicInCaseOfError()
+		orgId, err := rdeGetOrgId(client)
+		checkError(err)
+
+		var children []rdeChildInfo
+
+		if rdeBlueprintProjectName != "" {
+			bp, err := rdeFindBlueprintByProjectName(client, orgId, rdeBlueprintProjectName)
+			if err != nil {
+				utils.PrintlnError(err)
+				os.Exit(1)
+				panic("unreachable")
+			}
+			children, err = rdeListChildren(client, orgId, bp.ProjectId)
+			checkError(err)
+		} else {
+			children, err = rdeListAllChildren(client, orgId)
+			checkError(err)
+		}
+
+		if len(children) == 0 {
+			utils.Println("No RDE instances found.")
+			return
+		}
+
+		utils.Println(fmt.Sprintf("Starting %d RDE environment(s)...", len(children)))
+		for _, child := range children {
+			if child.EnvId != "" {
+				_, _, err := client.EnvironmentActionsAPI.DeployEnvironment(ctx(), child.EnvId).Execute()
+				if err != nil {
+					utils.Println(fmt.Sprintf("  Failed to start: %s (%v)", child.ProjectName, err))
+				} else {
+					utils.Println(fmt.Sprintf("  Started: %s", child.ProjectName))
+				}
+			}
+		}
+		utils.Println("Done.")
+	},
+}
+
+func init() {
+	rdeCmd.AddCommand(rdeStartAllCmd)
+	rdeStartAllCmd.Flags().StringVarP(&rdeBlueprintProjectName, "blueprint", "b", "", "Filter by Blueprint Project Name")
+	rdeStartAllCmd.Flags().StringVarP(&organizationName, "organization", "o", "", "Organization Name")
+}

--- a/cmd/rde_status.go
+++ b/cmd/rde_status.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/pterm/pterm"
 	"github.com/qovery/qovery-cli/utils"
 	"github.com/qovery/qovery-client-go"
 	"github.com/spf13/cobra"
@@ -28,31 +29,34 @@ var rdeStatusCmd = &cobra.Command{
 
 		bpName := rdeBlueprintNameForProjectId(client, child.BlueprintProjectId)
 
-		utils.Println(fmt.Sprintf("RDE: %s", child.ProjectName))
-		utils.Println(fmt.Sprintf("  Project:     %s", child.ProjectId))
-		utils.Println(fmt.Sprintf("  Environment: %s (%s)", child.EnvName, child.EnvId))
-		utils.Println(fmt.Sprintf("  Blueprint:   %s (%s)", bpName, child.BlueprintProjectId))
+		rows := [][]string{
+			{"RDE", pterm.FgBlue.Sprintf("%s", child.ProjectName)},
+			{"Project", child.ProjectId},
+			{"Environment", fmt.Sprintf("%s (%s)", child.EnvName, child.EnvId)},
+			{"Blueprint", fmt.Sprintf("%s (%s)", bpName, child.BlueprintProjectId)},
+		}
 
 		status, err := rdeGetEnvStatus(client, child.EnvId)
 		if err == nil {
-			utils.Println(fmt.Sprintf("  Status:      %s", utils.GetStatusTextWithColor(status)))
+			rows = append(rows, []string{"Status", utils.GetStatusTextWithColor(status)})
 		}
 
 		if status == qovery.STATEENUM_DEPLOYED || status == qovery.STATEENUM_RESTARTED {
 			url := rdeGetWorkspaceUrl(client, child.EnvId)
 			if url != "" {
-				utils.Println(fmt.Sprintf("  Workspace:   %s", url))
+				rows = append(rows, []string{"Workspace", url})
 			}
 		}
 
 		lastDeploy := rdeGetLastDeployTime(client, child.EnvId)
 		uptime := rdeFormatUptime(lastDeploy)
-		utils.Println(fmt.Sprintf("  Uptime:      %s", uptime))
-		utils.Println(fmt.Sprintf("  Console:     https://console.qovery.com/organization/%s/project/%s/environment/%s", orgId, child.ProjectId, child.EnvId))
+		rows = append(rows, []string{"Uptime", uptime})
+		rows = append(rows, []string{"Console", fmt.Sprintf("https://console.qovery.com/organization/%s/project/%s/environment/%s", orgId, child.ProjectId, child.EnvId)})
+
+		rdePrintKeyValueTable(rows)
 
 		// List services
 		utils.Println("")
-		utils.Println("  Services:")
 		rdePrintEnvServices(client, child.EnvId)
 	},
 }

--- a/cmd/rde_status.go
+++ b/cmd/rde_status.go
@@ -36,6 +36,10 @@ var rdeStatusCmd = &cobra.Command{
 			{"Blueprint", fmt.Sprintf("%s (%s)", bpName, child.BlueprintProjectId)},
 		}
 
+		if child.OwnerEmail != "" {
+			rows = append(rows, []string{"Owner", child.OwnerEmail})
+		}
+
 		status, err := rdeGetEnvStatus(client, child.EnvId)
 		if err == nil {
 			rows = append(rows, []string{"Status", utils.GetStatusTextWithColor(status)})

--- a/cmd/rde_status.go
+++ b/cmd/rde_status.go
@@ -1,0 +1,66 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/qovery/qovery-cli/utils"
+	"github.com/qovery/qovery-client-go"
+	"github.com/spf13/cobra"
+)
+
+var rdeStatusCmd = &cobra.Command{
+	Use:   "status",
+	Short: "Show detailed status of an RDE",
+	Run: func(cmd *cobra.Command, args []string) {
+		utils.Capture(cmd)
+
+		client := utils.GetQoveryClientPanicInCaseOfError()
+		orgId, err := rdeGetOrgId(client)
+		checkError(err)
+
+		child, err := rdeFindChildByName(client, orgId, fmt.Sprintf("rde-%s", rdeName))
+		if err != nil {
+			utils.PrintlnError(err)
+			os.Exit(1)
+			panic("unreachable")
+		}
+
+		bpName := rdeBlueprintNameForProjectId(client, child.BlueprintProjectId)
+
+		utils.Println(fmt.Sprintf("RDE: %s", child.ProjectName))
+		utils.Println(fmt.Sprintf("  Project:     %s", child.ProjectId))
+		utils.Println(fmt.Sprintf("  Environment: %s (%s)", child.EnvName, child.EnvId))
+		utils.Println(fmt.Sprintf("  Blueprint:   %s (%s)", bpName, child.BlueprintProjectId))
+
+		status, err := rdeGetEnvStatus(client, child.EnvId)
+		if err == nil {
+			utils.Println(fmt.Sprintf("  Status:      %s", utils.GetStatusTextWithColor(status)))
+		}
+
+		if status == qovery.STATEENUM_DEPLOYED || status == qovery.STATEENUM_RESTARTED {
+			url := rdeGetWorkspaceUrl(client, child.EnvId)
+			if url != "" {
+				utils.Println(fmt.Sprintf("  Workspace:   %s", url))
+			}
+		}
+
+		lastDeploy := rdeGetLastDeployTime(client, child.EnvId)
+		uptime := rdeFormatUptime(lastDeploy)
+		utils.Println(fmt.Sprintf("  Uptime:      %s", uptime))
+		utils.Println(fmt.Sprintf("  Console:     https://console.qovery.com/organization/%s/project/%s/environment/%s", orgId, child.ProjectId, child.EnvId))
+
+		// List services
+		utils.Println("")
+		utils.Println("  Services:")
+		rdePrintEnvServices(client, child.EnvId)
+	},
+}
+
+func init() {
+	rdeCmd.AddCommand(rdeStatusCmd)
+	rdeStatusCmd.Flags().StringVarP(&rdeName, "name", "n", "", "RDE Name")
+	rdeStatusCmd.Flags().StringVarP(&organizationName, "organization", "o", "", "Organization Name")
+
+	_ = rdeStatusCmd.MarkFlagRequired("name")
+}

--- a/cmd/rde_stop.go
+++ b/cmd/rde_stop.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/pterm/pterm"
 	"github.com/qovery/qovery-cli/utils"
 	"github.com/qovery/qovery-client-go"
 	"github.com/spf13/cobra"
@@ -27,7 +28,6 @@ var rdeStopCmd = &cobra.Command{
 			panic("unreachable")
 		}
 
-		utils.Println(fmt.Sprintf("Stopping RDE %s...", rdeName))
 		_, _, err = client.EnvironmentActionsAPI.StopEnvironment(ctx(), child.EnvId).Execute()
 		if err != nil {
 			utils.PrintlnError(fmt.Errorf("stop failed: %w", err))
@@ -35,7 +35,7 @@ var rdeStopCmd = &cobra.Command{
 			panic("unreachable")
 		}
 
-		utils.Println("  Stop triggered.")
+		utils.Println(fmt.Sprintf("Request to stop RDE %s has been queued..", pterm.FgBlue.Sprintf("%s", rdeName)))
 
 		if watchFlag {
 			time.Sleep(3 * time.Second)

--- a/cmd/rde_stop.go
+++ b/cmd/rde_stop.go
@@ -1,0 +1,54 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/qovery/qovery-cli/utils"
+	"github.com/qovery/qovery-client-go"
+	"github.com/spf13/cobra"
+)
+
+var rdeStopCmd = &cobra.Command{
+	Use:   "stop",
+	Short: "Stop an RDE",
+	Run: func(cmd *cobra.Command, args []string) {
+		utils.Capture(cmd)
+
+		client := utils.GetQoveryClientPanicInCaseOfError()
+		orgId, err := rdeGetOrgId(client)
+		checkError(err)
+
+		child, err := rdeFindChildByName(client, orgId, fmt.Sprintf("rde-%s", rdeName))
+		if err != nil {
+			utils.PrintlnError(err)
+			os.Exit(1)
+			panic("unreachable")
+		}
+
+		utils.Println(fmt.Sprintf("Stopping RDE %s...", rdeName))
+		_, _, err = client.EnvironmentActionsAPI.StopEnvironment(ctx(), child.EnvId).Execute()
+		if err != nil {
+			utils.PrintlnError(fmt.Errorf("stop failed: %w", err))
+			os.Exit(1)
+			panic("unreachable")
+		}
+
+		utils.Println("  Stop triggered.")
+
+		if watchFlag {
+			time.Sleep(3 * time.Second)
+			utils.WatchEnvironment(child.EnvId, qovery.STATEENUM_STOPPED, client)
+		}
+	},
+}
+
+func init() {
+	rdeCmd.AddCommand(rdeStopCmd)
+	rdeStopCmd.Flags().StringVarP(&rdeName, "name", "n", "", "RDE Name")
+	rdeStopCmd.Flags().StringVarP(&organizationName, "organization", "o", "", "Organization Name")
+	rdeStopCmd.Flags().BoolVarP(&watchFlag, "watch", "w", false, "Watch stop status until it completes or an error occurs")
+
+	_ = rdeStopCmd.MarkFlagRequired("name")
+}

--- a/cmd/rde_stop_all.go
+++ b/cmd/rde_stop_all.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/pterm/pterm"
 	"github.com/qovery/qovery-cli/utils"
 	"github.com/spf13/cobra"
 )
@@ -44,9 +45,9 @@ var rdeStopAllCmd = &cobra.Command{
 			if child.EnvId != "" {
 				_, _, err := client.EnvironmentActionsAPI.StopEnvironment(ctx(), child.EnvId).Execute()
 				if err != nil {
-					utils.Println(fmt.Sprintf("  Failed to stop: %s (%v)", child.ProjectName, err))
+					utils.Println(fmt.Sprintf("  Failed to stop: %s (%v)", pterm.FgBlue.Sprintf("%s", child.ProjectName), err))
 				} else {
-					utils.Println(fmt.Sprintf("  Stopped: %s", child.ProjectName))
+					utils.Println(fmt.Sprintf("  Request to stop %s has been queued..", pterm.FgBlue.Sprintf("%s", child.ProjectName)))
 				}
 			}
 		}

--- a/cmd/rde_stop_all.go
+++ b/cmd/rde_stop_all.go
@@ -1,0 +1,61 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/qovery/qovery-cli/utils"
+	"github.com/spf13/cobra"
+)
+
+var rdeStopAllCmd = &cobra.Command{
+	Use:   "stop-all",
+	Short: "Stop all RDE environments",
+	Run: func(cmd *cobra.Command, args []string) {
+		utils.Capture(cmd)
+
+		client := utils.GetQoveryClientPanicInCaseOfError()
+		orgId, err := rdeGetOrgId(client)
+		checkError(err)
+
+		var children []rdeChildInfo
+
+		if rdeBlueprintProjectName != "" {
+			bp, err := rdeFindBlueprintByProjectName(client, orgId, rdeBlueprintProjectName)
+			if err != nil {
+				utils.PrintlnError(err)
+				os.Exit(1)
+				panic("unreachable")
+			}
+			children, err = rdeListChildren(client, orgId, bp.ProjectId)
+			checkError(err)
+		} else {
+			children, err = rdeListAllChildren(client, orgId)
+			checkError(err)
+		}
+
+		if len(children) == 0 {
+			utils.Println("No RDE instances found.")
+			return
+		}
+
+		utils.Println(fmt.Sprintf("Stopping %d RDE environment(s)...", len(children)))
+		for _, child := range children {
+			if child.EnvId != "" {
+				_, _, err := client.EnvironmentActionsAPI.StopEnvironment(ctx(), child.EnvId).Execute()
+				if err != nil {
+					utils.Println(fmt.Sprintf("  Failed to stop: %s (%v)", child.ProjectName, err))
+				} else {
+					utils.Println(fmt.Sprintf("  Stopped: %s", child.ProjectName))
+				}
+			}
+		}
+		utils.Println("Done.")
+	},
+}
+
+func init() {
+	rdeCmd.AddCommand(rdeStopAllCmd)
+	rdeStopAllCmd.Flags().StringVarP(&rdeBlueprintProjectName, "blueprint", "b", "", "Filter by Blueprint Project Name")
+	rdeStopAllCmd.Flags().StringVarP(&organizationName, "organization", "o", "", "Organization Name")
+}

--- a/cmd/rde_upgrade.go
+++ b/cmd/rde_upgrade.go
@@ -79,10 +79,7 @@ If --name is provided, upgrades a single RDE. Otherwise, upgrades all RDEs.`,
 }
 
 func rdeUpgradeOne(client *qovery.APIClient, orgId string, child *rdeChildInfo) {
-	name := child.ProjectName
-	if strings.HasPrefix(name, "rde-") {
-		name = strings.TrimPrefix(name, "rde-")
-	}
+	name := strings.TrimPrefix(child.ProjectName, "rde-")
 
 	if rdeUpgradeStrategy == "image" {
 		utils.Println(fmt.Sprintf("  Upgrading %s (strategy: image - redeploy only)...", name))

--- a/cmd/rde_upgrade.go
+++ b/cmd/rde_upgrade.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/pterm/pterm"
 	"github.com/qovery/qovery-cli/utils"
 	"github.com/qovery/qovery-client-go"
 	"github.com/spf13/cobra"
@@ -82,7 +83,7 @@ func rdeUpgradeOne(client *qovery.APIClient, orgId string, child *rdeChildInfo) 
 	name := strings.TrimPrefix(child.ProjectName, "rde-")
 
 	if rdeUpgradeStrategy == "image" {
-		utils.Println(fmt.Sprintf("  Upgrading %s (strategy: image - redeploy only)...", name))
+		utils.Println(fmt.Sprintf("  Upgrading %s (strategy: image - redeploy only)...", pterm.FgBlue.Sprintf("%s", name)))
 		_, _, err := client.EnvironmentActionsAPI.DeployEnvironment(ctx(), child.EnvId).Execute()
 		if err != nil {
 			utils.Println(fmt.Sprintf("  WARNING: Deploy failed for %s: %v", name, err))
@@ -91,7 +92,7 @@ func rdeUpgradeOne(client *qovery.APIClient, orgId string, child *rdeChildInfo) 
 		}
 	} else {
 		// reclone strategy
-		utils.Println(fmt.Sprintf("  Upgrading %s (strategy: reclone - full re-clone from blueprint)...", name))
+		utils.Println(fmt.Sprintf("  Upgrading %s (strategy: reclone - full re-clone from blueprint)...", pterm.FgBlue.Sprintf("%s", name)))
 		utils.Println("    WARNING: Uncommitted changes will be lost. Code in git is safe.")
 
 		// Stop and delete the current environment

--- a/cmd/rde_upgrade.go
+++ b/cmd/rde_upgrade.go
@@ -1,0 +1,158 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/qovery/qovery-cli/utils"
+	"github.com/qovery/qovery-client-go"
+	"github.com/spf13/cobra"
+)
+
+var rdeUpgradeCmd = &cobra.Command{
+	Use:   "upgrade",
+	Short: "Upgrade RDE(s) from the updated blueprint",
+	Long: `Upgrade one or all RDE environments using one of two strategies:
+
+  image   (default) - Redeploy the environment (re-pulls latest images)
+  reclone           - Delete the environment, re-clone from blueprint, and deploy
+                      WARNING: uncommitted changes will be lost with reclone
+
+If --name is provided, upgrades a single RDE. Otherwise, upgrades all RDEs.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		utils.Capture(cmd)
+
+		if rdeUpgradeStrategy == "" {
+			rdeUpgradeStrategy = "image"
+		}
+		if rdeUpgradeStrategy != "image" && rdeUpgradeStrategy != "reclone" {
+			utils.PrintlnError(fmt.Errorf("unknown strategy '%s'. Use 'image' or 'reclone'", rdeUpgradeStrategy))
+			os.Exit(1)
+			panic("unreachable")
+		}
+
+		client := utils.GetQoveryClientPanicInCaseOfError()
+		orgId, err := rdeGetOrgId(client)
+		checkError(err)
+
+		if rdeName != "" {
+			// Upgrade a single RDE
+			child, err := rdeFindChildByName(client, orgId, fmt.Sprintf("rde-%s", rdeName))
+			if err != nil {
+				utils.PrintlnError(err)
+				os.Exit(1)
+				panic("unreachable")
+			}
+			rdeUpgradeOne(client, orgId, child)
+		} else {
+			// Upgrade all RDEs
+			var children []rdeChildInfo
+
+			if rdeBlueprintProjectName != "" {
+				bp, err := rdeFindBlueprintByProjectName(client, orgId, rdeBlueprintProjectName)
+				if err != nil {
+					utils.PrintlnError(err)
+					os.Exit(1)
+					panic("unreachable")
+				}
+				children, err = rdeListChildren(client, orgId, bp.ProjectId)
+				checkError(err)
+			} else {
+				children, err = rdeListAllChildren(client, orgId)
+				checkError(err)
+			}
+
+			if len(children) == 0 {
+				utils.Println("No RDE instances found.")
+				return
+			}
+
+			utils.Println(fmt.Sprintf("Upgrading %d RDE(s) (strategy: %s)...", len(children), rdeUpgradeStrategy))
+			for _, child := range children {
+				rdeUpgradeOne(client, orgId, &child)
+			}
+			utils.Println("\nAll RDEs upgraded.")
+		}
+	},
+}
+
+func rdeUpgradeOne(client *qovery.APIClient, orgId string, child *rdeChildInfo) {
+	name := child.ProjectName
+	if strings.HasPrefix(name, "rde-") {
+		name = strings.TrimPrefix(name, "rde-")
+	}
+
+	if rdeUpgradeStrategy == "image" {
+		utils.Println(fmt.Sprintf("  Upgrading %s (strategy: image - redeploy only)...", name))
+		_, _, err := client.EnvironmentActionsAPI.DeployEnvironment(ctx(), child.EnvId).Execute()
+		if err != nil {
+			utils.Println(fmt.Sprintf("  WARNING: Deploy failed for %s: %v", name, err))
+		} else {
+			utils.Println(fmt.Sprintf("  Deploy triggered for %s.", name))
+		}
+	} else {
+		// reclone strategy
+		utils.Println(fmt.Sprintf("  Upgrading %s (strategy: reclone - full re-clone from blueprint)...", name))
+		utils.Println("    WARNING: Uncommitted changes will be lost. Code in git is safe.")
+
+		// Stop and delete the current environment
+		_, _, _ = client.EnvironmentActionsAPI.StopEnvironment(ctx(), child.EnvId).Execute()
+		time.Sleep(2 * time.Second)
+		_, _ = client.EnvironmentMainCallsAPI.DeleteEnvironment(ctx(), child.EnvId).Execute()
+		time.Sleep(2 * time.Second)
+
+		// Re-clone from blueprint
+		cloneReq := qovery.CloneEnvironmentRequest{
+			Name:      "workspace",
+			ProjectId: &child.ProjectId,
+			Mode:      qovery.ENVIRONMENTMODEENUM_DEVELOPMENT.Ptr(),
+		}
+
+		newEnv, _, err := client.EnvironmentActionsAPI.CloneEnvironment(ctx(), child.BlueprintProjectId).
+			CloneEnvironmentRequest(cloneReq).Execute()
+		if err != nil {
+			utils.Println(fmt.Sprintf("    ERROR: Re-clone failed for %s: %v", name, err))
+			return
+		}
+
+		// Wait a moment for the clone to be processed, but we need the blueprint env ID, not project ID
+		// Find the blueprint environment
+		bpEnvInfo, err := rdeFindBlueprintEnv(client, child.BlueprintProjectId)
+		if err != nil || bpEnvInfo == nil {
+			utils.Println(fmt.Sprintf("    ERROR: Could not find blueprint environment for %s", name))
+			return
+		}
+
+		// Re-attempt clone from the actual blueprint environment
+		_, _ = client.EnvironmentMainCallsAPI.DeleteEnvironment(ctx(), newEnv.Id).Execute()
+		time.Sleep(1 * time.Second)
+
+		newEnv, _, err = client.EnvironmentActionsAPI.CloneEnvironment(ctx(), bpEnvInfo.EnvId).
+			CloneEnvironmentRequest(cloneReq).Execute()
+		if err != nil {
+			utils.Println(fmt.Sprintf("    ERROR: Re-clone failed for %s: %v", name, err))
+			return
+		}
+
+		// Update TTL job
+		rdeUpdateTTLJob(client, newEnv.Id)
+
+		// Deploy
+		_, _, err = client.EnvironmentActionsAPI.DeployEnvironment(ctx(), newEnv.Id).Execute()
+		if err != nil {
+			utils.Println(fmt.Sprintf("    WARNING: Deploy failed after re-clone for %s: %v", name, err))
+		} else {
+			utils.Println(fmt.Sprintf("    Re-cloned and deploying: %s", newEnv.Id))
+		}
+	}
+}
+
+func init() {
+	rdeCmd.AddCommand(rdeUpgradeCmd)
+	rdeUpgradeCmd.Flags().StringVarP(&rdeName, "name", "n", "", "RDE Name (omit to upgrade all)")
+	rdeUpgradeCmd.Flags().StringVarP(&rdeUpgradeStrategy, "strategy", "s", "image", "Upgrade strategy: 'image' (redeploy) or 'reclone' (full re-clone)")
+	rdeUpgradeCmd.Flags().StringVarP(&rdeBlueprintProjectName, "blueprint", "b", "", "Filter by Blueprint Project Name (when upgrading all)")
+	rdeUpgradeCmd.Flags().StringVarP(&organizationName, "organization", "o", "", "Organization Name")
+}

--- a/cmd/rde_urls.go
+++ b/cmd/rde_urls.go
@@ -1,0 +1,81 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/qovery/qovery-cli/utils"
+	"github.com/qovery/qovery-client-go"
+	"github.com/spf13/cobra"
+)
+
+var rdeUrlsCmd = &cobra.Command{
+	Use:   "urls",
+	Short: "List workspace URLs for running RDEs",
+	Run: func(cmd *cobra.Command, args []string) {
+		utils.Capture(cmd)
+
+		client := utils.GetQoveryClientPanicInCaseOfError()
+		orgId, err := rdeGetOrgId(client)
+		checkError(err)
+
+		var children []rdeChildInfo
+
+		if rdeBlueprintProjectName != "" {
+			bp, err := rdeFindBlueprintByProjectName(client, orgId, rdeBlueprintProjectName)
+			if err != nil {
+				utils.PrintlnError(err)
+				os.Exit(1)
+				panic("unreachable")
+			}
+			children, err = rdeListChildren(client, orgId, bp.ProjectId)
+			checkError(err)
+		} else {
+			children, err = rdeListAllChildren(client, orgId)
+			checkError(err)
+		}
+
+		if len(children) == 0 {
+			utils.Println("No RDE instances found.")
+			return
+		}
+
+		var data [][]string
+		for _, child := range children {
+			if child.EnvId == "" {
+				continue
+			}
+			status, err := rdeGetEnvStatus(client, child.EnvId)
+			if err != nil {
+				continue
+			}
+			if status == qovery.STATEENUM_DEPLOYED || status == qovery.STATEENUM_RESTARTED {
+				url := rdeGetWorkspaceUrl(client, child.EnvId)
+				if url == "" {
+					url = "-"
+				}
+				data = append(data, []string{child.ProjectName, url})
+			}
+		}
+
+		if len(data) == 0 {
+			utils.Println("No running RDEs with workspace URLs found.")
+			return
+		}
+
+		err = utils.PrintTable([]string{"Name", "Workspace URL"}, data)
+		if err != nil {
+			utils.PrintlnError(err)
+			os.Exit(1)
+			panic("unreachable")
+		}
+
+		utils.Println(fmt.Sprintf("\n%d running RDE(s) with workspace URLs.", len(data)))
+	},
+}
+
+func init() {
+	rdeCmd.AddCommand(rdeUrlsCmd)
+	rdeUrlsCmd.Flags().StringVarP(&rdeBlueprintProjectName, "blueprint", "b", "", "Filter by Blueprint Project Name")
+	rdeUrlsCmd.Flags().StringVarP(&organizationName, "organization", "o", "", "Organization Name")
+}


### PR DESCRIPTION
## Summary

- Add `qovery rde` command group for managing Remote Development Environments (RDE), enabling platform teams to provision isolated, pre-configured dev environments from blueprint templates
- Implement 21 new command files covering blueprint management, RDE lifecycle, bulk operations, and advanced features (upgrade, urls, logs, info)
- Use environment variables (`BLUEPRINT_PROJECT_ID` at project level, `BLUEPRINT_KEY` at environment level) for blueprint identification -- no naming convention required

## Architecture

### Identification Model

```
Blueprint Project
  ├── Project-level env var: BLUEPRINT_PROJECT_ID = <own project ID>
  └── Blueprint Environment
      └── Env-level env var: BLUEPRINT_KEY = <own project ID>

Child Project (cloned RDE)
  └── Child Environment (cloned from blueprint)
      └── Env-level env var: BLUEPRINT_KEY = <blueprint project ID>  ← different from own project
```

**Discovery logic:**
- `BLUEPRINT_KEY == own project ID` → blueprint master
- `BLUEPRINT_KEY != own project ID` → child of that blueprint

### Command Tree

```
qovery rde
  ├── blueprint
  │   ├── create   --project <name>
  │   ├── list     [--json]
  │   ├── delete   --project <name>
  │   ├── status   --project <name>
  │   ├── deploy   --project <name> [--watch]
  │   └── stop     --project <name> [--watch]
  ├── create       --blueprint <name> --name <rde-name> [--email] [--skip-rbac] [--skip-invite] [--skip-deploy]
  ├── list         [--blueprint <name>] [--json]
  ├── status       --name <rde-name>
  ├── start        --name <rde-name> [--watch]
  ├── stop         --name <rde-name> [--watch]
  ├── delete       --name <rde-name>
  ├── stop-all     [--blueprint <name>]
  ├── start-all    [--blueprint <name>]
  ├── delete-all   --confirm [--blueprint <name>]
  ├── upgrade      [--name <rde-name>] [--strategy image|reclone]
  ├── urls         [--blueprint <name>]
  ├── logs         --name <rde-name>
  └── info
```

### RDE Provisioning (`rde create`) Steps

1. Create project `rde-<name>` with description
2. Create RBAC role `RDE-<name>` with scoped permissions (optional)
3. Clone blueprint environment into new project
4. Handle TTL job from blueprint
5. Invite developer via email (optional)
6. Trigger deployment (optional)

## API Methods Used

Uses the `qovery-client-go` typed client throughout (no raw HTTP calls):
- `ProjectsAPI` for project CRUD
- `EnvironmentActionsAPI` for clone, deploy, stop
- `EnvironmentMainCallsAPI` for delete, status
- `OrganizationCustomRoleAPI` for RBAC role management
- `MembersAPI` for member invitation
- `VariableMainCallsAPI` for blueprint identification via env vars
- `ApplicationMainCallsAPI` for workspace URL resolution
- `JobsAPI` / `JobMainCallsAPI` for TTL job handling
- `OrganizationApiTokenAPI` for cleanup

## Testing

- Binary builds cleanly: `go build`
- All `cmd` package tests pass: `go test -tags testing ./cmd/...`
- Pre-existing test failure in `utils/context_test.go` (unrelated undefined symbols) -- not introduced by this PR