### PR TITLE
fix(rde): fix upgrade reclone 404 + implement image strategy with blueprint sync

### DIFF
--- a/cmd/rde.go
+++ b/cmd/rde.go
@@ -532,3 +532,49 @@ func rdeBlueprintNameForProjectId(client *qovery.APIClient, projectId string) st
 	}
 	return project.Name
 }
+
+// rdeGetBlueprintClusterId returns the cluster ID of the blueprint environment.
+func rdeGetBlueprintClusterId(client *qovery.APIClient, blueprintEnvId string) string {
+	env, _, err := client.EnvironmentMainCallsAPI.GetEnvironment(ctx(), blueprintEnvId).Execute()
+	if err != nil {
+		return ""
+	}
+	return env.ClusterId
+}
+
+// rdeIsEnvDeleted checks if an environment no longer exists (404) or is in a terminal deleted state.
+func rdeIsEnvDeleted(client *qovery.APIClient, envId string) bool {
+	_, resp, err := client.EnvironmentMainCallsAPI.GetEnvironmentStatuses(ctx(), envId).Execute()
+	if err != nil {
+		// If 404, it's deleted
+		if resp != nil && resp.StatusCode == 404 {
+			return true
+		}
+		return false
+	}
+	return false
+}
+
+// rdeWaitForEnvsDeletion waits for multiple environments to be deleted, polling until they return 404 or timeout.
+func rdeWaitForEnvsDeletion(client *qovery.APIClient, envIds []string, timeout time.Duration) {
+	deadline := time.Now().Add(timeout)
+	remaining := make(map[string]bool)
+	for _, id := range envIds {
+		remaining[id] = true
+	}
+
+	for len(remaining) > 0 && time.Now().Before(deadline) {
+		for id := range remaining {
+			if rdeIsEnvDeleted(client, id) {
+				delete(remaining, id)
+			}
+		}
+		if len(remaining) > 0 {
+			time.Sleep(5 * time.Second)
+		}
+	}
+
+	if len(remaining) > 0 {
+		utils.PrintlnInfo(fmt.Sprintf("%d environment(s) did not finish deleting within timeout, proceeding anyway", len(remaining)))
+	}
+}

--- a/cmd/rde_sync.go
+++ b/cmd/rde_sync.go
@@ -1,0 +1,535 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/pterm/pterm"
+	"github.com/qovery/qovery-cli/utils"
+	"github.com/qovery/qovery-client-go"
+)
+
+// Sync option flags (set in rde_upgrade.go init)
+var rdeSyncAll bool
+var rdeSyncResources bool
+var rdeSyncPorts bool
+var rdeSyncHealthchecks bool
+var rdeSyncStorage bool
+
+// rdeSyncServicesFromBlueprint reads all services from the blueprint environment and updates
+// the matching services in the child environment. Services are matched by name.
+// Source/image config is always synced. Additional config is synced based on flags.
+func rdeSyncServicesFromBlueprint(client *qovery.APIClient, blueprintEnvId string, childEnvId string) int {
+	synced := 0
+	synced += rdeSyncContainers(client, blueprintEnvId, childEnvId)
+	synced += rdeSyncApplications(client, blueprintEnvId, childEnvId)
+	synced += rdeSyncJobs(client, blueprintEnvId, childEnvId)
+	synced += rdeSyncHelms(client, blueprintEnvId, childEnvId)
+	return synced
+}
+
+// --- Container sync ---
+
+func rdeSyncContainers(client *qovery.APIClient, blueprintEnvId string, childEnvId string) int {
+	bpContainers, _, err := client.ContainersAPI.ListContainer(ctx(), blueprintEnvId).Execute()
+	if err != nil || bpContainers == nil {
+		return 0
+	}
+	childContainers, _, err := client.ContainersAPI.ListContainer(ctx(), childEnvId).Execute()
+	if err != nil || childContainers == nil {
+		return 0
+	}
+
+	bpMap := make(map[string]qovery.ContainerResponse)
+	for _, c := range bpContainers.GetResults() {
+		bpMap[c.Name] = c
+	}
+
+	synced := 0
+	for _, child := range childContainers.GetResults() {
+		bp, ok := bpMap[child.Name]
+		if !ok {
+			continue
+		}
+
+		// Build storage from child or blueprint
+		var storage []qovery.ServiceStorageRequestStorageInner
+		srcStorage := child.Storage
+		if rdeSyncAll || rdeSyncStorage {
+			srcStorage = bp.Storage
+		}
+		for _, s := range srcStorage {
+			storage = append(storage, qovery.ServiceStorageRequestStorageInner{
+				Id:         &s.Id,
+				Type:       s.Type,
+				Size:       s.Size,
+				MountPoint: s.MountPoint,
+			})
+		}
+
+		// Build ports from child or blueprint
+		var ports []qovery.ServicePortRequestPortsInner
+		srcPorts := child.Ports
+		if rdeSyncAll || rdeSyncPorts {
+			srcPorts = bp.Ports
+		}
+		for _, p := range srcPorts {
+			ports = append(ports, qovery.ServicePortRequestPortsInner{
+				Name:               p.Name,
+				InternalPort:       p.InternalPort,
+				ExternalPort:       p.ExternalPort,
+				PubliclyAccessible: p.PubliclyAccessible,
+				IsDefault:          p.IsDefault,
+				Protocol:           &p.Protocol,
+			})
+		}
+
+		cpu := utils.Int32(child.Cpu)
+		memory := utils.Int32(child.Memory)
+		minInst := utils.Int32(child.MinRunningInstances)
+		maxInst := utils.Int32(child.MaxRunningInstances)
+		autoscaling := utils.ConvertAutoscalingResponseToRequest(child.Autoscaling)
+		if rdeSyncAll || rdeSyncResources {
+			cpu = utils.Int32(bp.Cpu)
+			memory = utils.Int32(bp.Memory)
+			minInst = utils.Int32(bp.MinRunningInstances)
+			maxInst = utils.Int32(bp.MaxRunningInstances)
+			autoscaling = utils.ConvertAutoscalingResponseToRequest(bp.Autoscaling)
+		}
+
+		healthchecks := child.Healthchecks
+		if rdeSyncAll || rdeSyncHealthchecks {
+			healthchecks = bp.Healthchecks
+		}
+
+		req := qovery.ContainerRequest{
+			Storage:             storage,
+			Ports:               ports,
+			Name:                child.Name,
+			Description:         child.Description,
+			RegistryId:          bp.Registry.Id, // always sync source
+			ImageName:           bp.ImageName,   // always sync source
+			Tag:                 bp.Tag,         // always sync source
+			Arguments:           child.Arguments,
+			Entrypoint:          child.Entrypoint,
+			Cpu:                 cpu,
+			Memory:              memory,
+			MinRunningInstances: minInst,
+			MaxRunningInstances: maxInst,
+			Healthchecks:        healthchecks,
+			AutoPreview:         utils.Bool(child.AutoPreview),
+			AutoDeploy:          *qovery.NewNullableBool(child.AutoDeploy),
+			Autoscaling:         autoscaling,
+		}
+
+		_, _, err := client.ContainerMainCallsAPI.EditContainer(ctx(), child.Id).ContainerRequest(req).Execute()
+		if err != nil {
+			utils.Println(fmt.Sprintf("    WARNING: Failed to sync container %s: %v", child.Name, err))
+		} else {
+			utils.Println(fmt.Sprintf("    Synced container: %s (tag: %s)", pterm.FgBlue.Sprintf("%s", child.Name), bp.Tag))
+			synced++
+		}
+	}
+
+	return synced
+}
+
+// --- Application sync ---
+
+func rdeSyncApplications(client *qovery.APIClient, blueprintEnvId string, childEnvId string) int {
+	bpApps, _, err := client.ApplicationsAPI.ListApplication(ctx(), blueprintEnvId).Execute()
+	if err != nil || bpApps == nil {
+		return 0
+	}
+	childApps, _, err := client.ApplicationsAPI.ListApplication(ctx(), childEnvId).Execute()
+	if err != nil || childApps == nil {
+		return 0
+	}
+
+	bpMap := make(map[string]qovery.Application)
+	for _, a := range bpApps.GetResults() {
+		bpMap[a.Name] = a
+	}
+
+	synced := 0
+	for _, child := range childApps.GetResults() {
+		bp, ok := bpMap[child.Name]
+		if !ok {
+			continue
+		}
+
+		// Build git repository request from blueprint (always sync source)
+		var gitRepo *qovery.ApplicationGitRepositoryRequest
+		if bp.GitRepository != nil {
+			gitRepo = &qovery.ApplicationGitRepositoryRequest{
+				Url:      bp.GitRepository.Url,
+				Branch:   bp.GitRepository.Branch,
+				RootPath: bp.GitRepository.RootPath,
+				Provider: bp.GitRepository.Provider,
+			}
+		}
+
+		var storage []qovery.ServiceStorageRequestStorageInner
+		srcStorage := child.Storage
+		if rdeSyncAll || rdeSyncStorage {
+			srcStorage = bp.Storage
+		}
+		for _, s := range srcStorage {
+			storage = append(storage, qovery.ServiceStorageRequestStorageInner{
+				Id:         &s.Id,
+				Type:       s.Type,
+				Size:       s.Size,
+				MountPoint: s.MountPoint,
+			})
+		}
+
+		cpu := child.Cpu
+		memory := child.Memory
+		minInst := child.MinRunningInstances
+		maxInst := child.MaxRunningInstances
+		if rdeSyncAll || rdeSyncResources {
+			cpu = bp.Cpu
+			memory = bp.Memory
+			minInst = bp.MinRunningInstances
+			maxInst = bp.MaxRunningInstances
+		}
+
+		healthchecks := child.Healthchecks
+		if rdeSyncAll || rdeSyncHealthchecks {
+			healthchecks = bp.Healthchecks
+		}
+
+		ports := child.Ports
+		if rdeSyncAll || rdeSyncPorts {
+			ports = bp.Ports
+		}
+
+		req := qovery.ApplicationEditRequest{
+			Storage:             storage,
+			Name:                &child.Name,
+			Description:         child.Description,
+			GitRepository:       gitRepo,           // always sync source
+			BuildMode:           bp.BuildMode,      // always sync source
+			DockerfilePath:      bp.DockerfilePath, // always sync source
+			Cpu:                 cpu,
+			Memory:              memory,
+			MinRunningInstances: minInst,
+			MaxRunningInstances: maxInst,
+			Healthchecks:        healthchecks,
+			AutoPreview:         child.AutoPreview,
+			Ports:               ports,
+			Arguments:           child.Arguments,
+			Entrypoint:          child.Entrypoint,
+			AutoDeploy:          *qovery.NewNullableBool(child.AutoDeploy),
+		}
+
+		_, _, err := client.ApplicationMainCallsAPI.EditApplication(ctx(), child.Id).ApplicationEditRequest(req).Execute()
+		if err != nil {
+			utils.Println(fmt.Sprintf("    WARNING: Failed to sync application %s: %v", child.Name, err))
+		} else {
+			branch := ""
+			if bp.GitRepository != nil && bp.GitRepository.Branch != nil {
+				branch = *bp.GitRepository.Branch
+			}
+			utils.Println(fmt.Sprintf("    Synced application: %s (branch: %s)", pterm.FgBlue.Sprintf("%s", child.Name), branch))
+			synced++
+		}
+	}
+
+	return synced
+}
+
+// --- Job sync ---
+
+func rdeSyncJobs(client *qovery.APIClient, blueprintEnvId string, childEnvId string) int {
+	bpJobs, _, err := client.JobsAPI.ListJobs(ctx(), blueprintEnvId).Execute()
+	if err != nil || bpJobs == nil {
+		return 0
+	}
+	childJobs, _, err := client.JobsAPI.ListJobs(ctx(), childEnvId).Execute()
+	if err != nil || childJobs == nil {
+		return 0
+	}
+
+	bpMap := make(map[string]qovery.JobResponse)
+	for _, j := range bpJobs.GetResults() {
+		bpMap[utils.GetJobName(&j)] = j
+	}
+
+	synced := 0
+	for _, childJob := range childJobs.GetResults() {
+		childName := utils.GetJobName(&childJob)
+		bp, ok := bpMap[childName]
+		if !ok {
+			continue
+		}
+
+		childId := utils.GetJobId(&childJob)
+		bpSource := rdeJobResponseToRequestSource(&bp)
+		childDetail := rdeExtractJobDetail(&childJob)
+		if childDetail == nil || bpSource == nil {
+			continue
+		}
+
+		cpu := childDetail.cpu
+		memory := childDetail.memory
+		if rdeSyncAll || rdeSyncResources {
+			bpDetail := rdeExtractJobDetail(&bp)
+			if bpDetail != nil {
+				cpu = bpDetail.cpu
+				memory = bpDetail.memory
+			}
+		}
+
+		healthchecks := childDetail.healthchecks
+		if rdeSyncAll || rdeSyncHealthchecks {
+			bpDetail := rdeExtractJobDetail(&bp)
+			if bpDetail != nil {
+				healthchecks = bpDetail.healthchecks
+			}
+		}
+
+		req := qovery.JobRequest{
+			Name:               childName,
+			Description:        childDetail.description,
+			Cpu:                cpu,
+			Memory:             memory,
+			MaxNbRestart:       childDetail.maxNbRestart,
+			MaxDurationSeconds: childDetail.maxDurationSeconds,
+			AutoPreview:        childDetail.autoPreview,
+			Port:               childDetail.port,
+			Source:             bpSource, // always sync source
+			Healthchecks:       healthchecks,
+			Schedule:           childDetail.schedule,
+			AutoDeploy:         childDetail.autoDeploy,
+		}
+
+		_, _, err := client.JobMainCallsAPI.EditJob(ctx(), childId).JobRequest(req).Execute()
+		if err != nil {
+			utils.Println(fmt.Sprintf("    WARNING: Failed to sync job %s: %v", childName, err))
+		} else {
+			utils.Println(fmt.Sprintf("    Synced job: %s", pterm.FgBlue.Sprintf("%s", childName)))
+			synced++
+		}
+	}
+
+	return synced
+}
+
+// rdeJobResponseToRequestSource converts a JobResponse source to a JobRequestAllOfSource.
+func rdeJobResponseToRequestSource(job *qovery.JobResponse) *qovery.JobRequestAllOfSource {
+	var source qovery.BaseJobResponseAllOfSource
+	if job.CronJobResponse != nil {
+		source = job.CronJobResponse.Source
+	} else if job.LifecycleJobResponse != nil {
+		source = job.LifecycleJobResponse.Source
+	} else {
+		return nil
+	}
+
+	result := &qovery.JobRequestAllOfSource{}
+
+	if source.BaseJobResponseAllOfSourceOneOf != nil {
+		// Image source
+		img := source.BaseJobResponseAllOfSourceOneOf.Image
+		reqImg := qovery.NewNullableJobRequestAllOfSourceImage(
+			&qovery.JobRequestAllOfSourceImage{
+				ImageName:  &img.ImageName,
+				Tag:        &img.Tag,
+				RegistryId: img.RegistryId,
+			},
+		)
+		result.Image = *reqImg
+	} else if source.BaseJobResponseAllOfSourceOneOf1 != nil {
+		// Docker/git source
+		docker := source.BaseJobResponseAllOfSourceOneOf1.Docker
+		var gitRepo *qovery.ApplicationGitRepositoryRequest
+		if docker.GitRepository != nil {
+			gitRepo = &qovery.ApplicationGitRepositoryRequest{
+				Url:      docker.GitRepository.Url,
+				Branch:   docker.GitRepository.Branch,
+				RootPath: docker.GitRepository.RootPath,
+				Provider: docker.GitRepository.Provider,
+			}
+		}
+		reqDocker := qovery.NewNullableJobRequestAllOfSourceDocker(
+			&qovery.JobRequestAllOfSourceDocker{
+				GitRepository:          gitRepo,
+				DockerfilePath:         docker.DockerfilePath,
+				DockerfileRaw:          docker.DockerfileRaw,
+				DockerTargetBuildStage: docker.DockerTargetBuildStage,
+			},
+		)
+		result.Docker = *reqDocker
+	}
+
+	return result
+}
+
+// jobDetail holds common fields from CronJobResponse or LifecycleJobResponse.
+type jobDetail struct {
+	cpu                *int32
+	memory             *int32
+	description        *string
+	maxNbRestart       *int32
+	maxDurationSeconds *int32
+	autoPreview        *bool
+	port               qovery.NullableInt32
+	healthchecks       qovery.Healthcheck
+	schedule           *qovery.JobRequestAllOfSchedule
+	autoDeploy         qovery.NullableBool
+}
+
+// rdeExtractJobDetail extracts common fields from a JobResponse.
+func rdeExtractJobDetail(job *qovery.JobResponse) *jobDetail {
+	if job.CronJobResponse != nil {
+		cj := job.CronJobResponse
+		cpu := cj.Cpu
+		mem := cj.Memory
+		autoPreview := utils.Bool(cj.AutoPreview)
+		tz := cj.Schedule.Cronjob.Timezone
+		schedule := &qovery.JobRequestAllOfSchedule{
+			Cronjob: &qovery.JobRequestAllOfScheduleCronjob{
+				ScheduledAt: cj.Schedule.Cronjob.ScheduledAt,
+				Timezone:    &tz,
+				Entrypoint:  cj.Schedule.Cronjob.Entrypoint,
+				Arguments:   cj.Schedule.Cronjob.Arguments,
+			},
+		}
+		return &jobDetail{
+			cpu: &cpu, memory: &mem,
+			description: cj.Description, maxNbRestart: cj.MaxNbRestart,
+			maxDurationSeconds: cj.MaxDurationSeconds, autoPreview: autoPreview,
+			port: cj.Port, healthchecks: cj.Healthchecks, schedule: schedule,
+			autoDeploy: *qovery.NewNullableBool(cj.AutoDeploy),
+		}
+	} else if job.LifecycleJobResponse != nil {
+		lj := job.LifecycleJobResponse
+		cpu := lj.Cpu
+		mem := lj.Memory
+		autoPreview := utils.Bool(lj.AutoPreview)
+		schedule := &qovery.JobRequestAllOfSchedule{}
+		if lj.Schedule.OnStart != nil {
+			schedule.OnStart = &qovery.JobRequestAllOfScheduleOnStart{
+				Entrypoint: lj.Schedule.OnStart.Entrypoint,
+				Arguments:  lj.Schedule.OnStart.Arguments,
+			}
+		}
+		if lj.Schedule.OnStop != nil {
+			schedule.OnStop = &qovery.JobRequestAllOfScheduleOnStart{
+				Entrypoint: lj.Schedule.OnStop.Entrypoint,
+				Arguments:  lj.Schedule.OnStop.Arguments,
+			}
+		}
+		if lj.Schedule.OnDelete != nil {
+			schedule.OnDelete = &qovery.JobRequestAllOfScheduleOnStart{
+				Entrypoint: lj.Schedule.OnDelete.Entrypoint,
+				Arguments:  lj.Schedule.OnDelete.Arguments,
+			}
+		}
+		return &jobDetail{
+			cpu: &cpu, memory: &mem,
+			description: lj.Description, maxNbRestart: lj.MaxNbRestart,
+			maxDurationSeconds: lj.MaxDurationSeconds, autoPreview: autoPreview,
+			port: lj.Port, healthchecks: lj.Healthchecks, schedule: schedule,
+			autoDeploy: *qovery.NewNullableBool(lj.AutoDeploy),
+		}
+	}
+	return nil
+}
+
+// --- Helm sync ---
+
+func rdeSyncHelms(client *qovery.APIClient, blueprintEnvId string, childEnvId string) int {
+	bpHelms, _, err := client.HelmsAPI.ListHelms(ctx(), blueprintEnvId).Execute()
+	if err != nil || bpHelms == nil {
+		return 0
+	}
+	childHelms, _, err := client.HelmsAPI.ListHelms(ctx(), childEnvId).Execute()
+	if err != nil || childHelms == nil {
+		return 0
+	}
+
+	bpMap := make(map[string]qovery.HelmResponse)
+	for _, h := range bpHelms.GetResults() {
+		bpMap[h.Name] = h
+	}
+
+	synced := 0
+	for _, child := range childHelms.GetResults() {
+		bp, ok := bpMap[child.Name]
+		if !ok {
+			continue
+		}
+
+		bpSource := rdeConvertHelmSource(&bp.Source)
+		if bpSource == nil {
+			continue
+		}
+
+		childValues := rdeConvertHelmValuesOverride(&child.ValuesOverride)
+
+		req := qovery.HelmRequest{
+			Name:                      child.Name,
+			Description:               child.Description,
+			TimeoutSec:                child.TimeoutSec,
+			AutoDeploy:                child.AutoDeploy,
+			Source:                    *bpSource, // always sync source
+			Arguments:                 child.Arguments,
+			AllowClusterWideResources: &child.AllowClusterWideResources,
+			ValuesOverride:            *childValues,
+		}
+
+		_, _, err := client.HelmMainCallsAPI.EditHelm(ctx(), child.Id).HelmRequest(req).Execute()
+		if err != nil {
+			utils.Println(fmt.Sprintf("    WARNING: Failed to sync helm %s: %v", child.Name, err))
+		} else {
+			utils.Println(fmt.Sprintf("    Synced helm: %s", pterm.FgBlue.Sprintf("%s", child.Name)))
+			synced++
+		}
+	}
+
+	return synced
+}
+
+// rdeConvertHelmSource converts a HelmResponseAllOfSource to a HelmRequestAllOfSource.
+func rdeConvertHelmSource(src *qovery.HelmResponseAllOfSource) *qovery.HelmRequestAllOfSource {
+	if src.HelmResponseAllOfSourceOneOf != nil {
+		// Git source
+		gitSrc := src.HelmResponseAllOfSourceOneOf.Git
+		gitRepo := &qovery.HelmGitRepositoryRequest{
+			Url:      gitSrc.GitRepository.Url,
+			Branch:   gitSrc.GitRepository.Branch,
+			RootPath: gitSrc.GitRepository.RootPath,
+		}
+		return &qovery.HelmRequestAllOfSource{
+			HelmRequestAllOfSourceOneOf: &qovery.HelmRequestAllOfSourceOneOf{
+				GitRepository: gitRepo,
+			},
+		}
+	} else if src.HelmResponseAllOfSourceOneOf1 != nil {
+		// Repository source
+		repoSrc := src.HelmResponseAllOfSourceOneOf1.Repository
+		repoId := repoSrc.Repository.Id
+		repoNullable := qovery.NullableString{}
+		repoNullable.Set(&repoId)
+		return &qovery.HelmRequestAllOfSource{
+			HelmRequestAllOfSourceOneOf1: &qovery.HelmRequestAllOfSourceOneOf1{
+				HelmRepository: &qovery.HelmRequestAllOfSourceOneOf1HelmRepository{
+					Repository:   repoNullable,
+					ChartName:    &repoSrc.ChartName,
+					ChartVersion: &repoSrc.ChartVersion,
+				},
+			},
+		}
+	}
+	return nil
+}
+
+// rdeConvertHelmValuesOverride converts HelmResponseAllOfValuesOverride to HelmRequestAllOfValuesOverride.
+func rdeConvertHelmValuesOverride(v *qovery.HelmResponseAllOfValuesOverride) *qovery.HelmRequestAllOfValuesOverride {
+	return &qovery.HelmRequestAllOfValuesOverride{
+		Set:       v.Set,
+		SetString: v.SetString,
+		SetJson:   v.SetJson,
+	}
+}

--- a/cmd/rde_upgrade.go
+++ b/cmd/rde_upgrade.go
@@ -21,7 +21,9 @@ var rdeUpgradeCmd = &cobra.Command{
   reclone           - Delete the environment, re-clone from blueprint, and deploy
                       WARNING: uncommitted changes will be lost with reclone
 
-If --name is provided, upgrades a single RDE. Otherwise, upgrades all RDEs.`,
+If --name is provided, upgrades a single RDE. Otherwise, upgrades all RDEs.
+When upgrading multiple RDEs with reclone, environments are deleted in parallel
+for faster execution.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Capture(cmd)
 
@@ -46,7 +48,12 @@ If --name is provided, upgrades a single RDE. Otherwise, upgrades all RDEs.`,
 				os.Exit(1)
 				panic("unreachable")
 			}
-			rdeUpgradeOne(client, orgId, child)
+
+			if rdeUpgradeStrategy == "image" {
+				rdeUpgradeImage(client, child)
+			} else {
+				rdeUpgradeRecloneSingle(client, child)
+			}
 		} else {
 			// Upgrade all RDEs
 			var children []rdeChildInfo
@@ -71,86 +78,224 @@ If --name is provided, upgrades a single RDE. Otherwise, upgrades all RDEs.`,
 			}
 
 			utils.Println(fmt.Sprintf("Upgrading %d RDE(s) (strategy: %s)...", len(children), rdeUpgradeStrategy))
-			for _, child := range children {
-				rdeUpgradeOne(client, orgId, &child)
+
+			if rdeUpgradeStrategy == "image" {
+				for _, child := range children {
+					rdeUpgradeImage(client, &child)
+				}
+			} else {
+				rdeUpgradeRecloneAll(client, children)
 			}
 			utils.Println("\nAll RDEs upgraded.")
 		}
 	},
 }
 
-func rdeUpgradeOne(client *qovery.APIClient, orgId string, child *rdeChildInfo) {
+// rdeUpgradeImage triggers a redeploy of an RDE environment.
+func rdeUpgradeImage(client *qovery.APIClient, child *rdeChildInfo) {
 	name := strings.TrimPrefix(child.ProjectName, "rde-")
+	utils.Println(fmt.Sprintf("  Upgrading %s (strategy: image - sync from blueprint and deploy)...", pterm.FgBlue.Sprintf("%s", name)))
 
-	if rdeUpgradeStrategy == "image" {
-		utils.Println(fmt.Sprintf("  Upgrading %s (strategy: image - redeploy only)...", pterm.FgBlue.Sprintf("%s", name)))
-		_, _, err := client.EnvironmentActionsAPI.DeployEnvironment(ctx(), child.EnvId).Execute()
-		if err != nil {
-			utils.Println(fmt.Sprintf("  WARNING: Deploy failed for %s: %v", name, err))
-		} else {
-			utils.Println(fmt.Sprintf("  Deploy triggered for %s.", name))
-		}
+	// Resolve blueprint environment ID
+	bpEnvInfo, err := rdeFindBlueprintEnv(client, child.BlueprintProjectId)
+	if err != nil || bpEnvInfo == nil {
+		utils.Println(fmt.Sprintf("    ERROR: Could not find blueprint environment for %s", name))
+		return
+	}
+
+	// Sync service configurations from blueprint
+	synced := rdeSyncServicesFromBlueprint(client, bpEnvInfo.EnvId, child.EnvId)
+	if synced == 0 {
+		utils.Println(fmt.Sprintf("    No services matched between blueprint and %s, deploying as-is...", name))
 	} else {
-		// reclone strategy
-		utils.Println(fmt.Sprintf("  Upgrading %s (strategy: reclone - full re-clone from blueprint)...", pterm.FgBlue.Sprintf("%s", name)))
-		utils.Println("    WARNING: Uncommitted changes will be lost. Code in git is safe.")
+		utils.Println(fmt.Sprintf("    Synced %d service(s) from blueprint.", synced))
+	}
 
-		// Stop and delete the current environment
-		_, _, _ = client.EnvironmentActionsAPI.StopEnvironment(ctx(), child.EnvId).Execute()
-		time.Sleep(2 * time.Second)
+	// Deploy
+	_, _, err = client.EnvironmentActionsAPI.DeployEnvironment(ctx(), child.EnvId).Execute()
+	if err != nil {
+		utils.Println(fmt.Sprintf("    WARNING: Deploy failed for %s: %v", name, err))
+	} else {
+		utils.Println(fmt.Sprintf("    Request to deploy %s has been queued..", pterm.FgBlue.Sprintf("%s", name)))
+	}
+}
+
+// rdeUpgradeRecloneSingle upgrades a single RDE by deleting its environment, waiting, and re-cloning from the blueprint.
+func rdeUpgradeRecloneSingle(client *qovery.APIClient, child *rdeChildInfo) {
+	name := strings.TrimPrefix(child.ProjectName, "rde-")
+	utils.Println(fmt.Sprintf("  Upgrading %s (strategy: reclone - full re-clone from blueprint)...", pterm.FgBlue.Sprintf("%s", name)))
+	utils.Println("    WARNING: Uncommitted changes will be lost. Code in git is safe.")
+
+	// Resolve blueprint environment ID
+	bpEnvInfo, err := rdeFindBlueprintEnv(client, child.BlueprintProjectId)
+	if err != nil || bpEnvInfo == nil {
+		utils.Println(fmt.Sprintf("    ERROR: Could not find blueprint environment for %s", name))
+		return
+	}
+
+	// Get blueprint cluster ID
+	bpClusterId := rdeGetBlueprintClusterId(client, bpEnvInfo.EnvId)
+
+	// Preserve owner email
+	ownerEmail := child.OwnerEmail
+
+	// Delete the current environment
+	utils.Println(fmt.Sprintf("    Deleting environment %s...", pterm.FgBlue.Sprintf("%s", child.EnvName)))
+	_, _ = client.EnvironmentMainCallsAPI.DeleteEnvironment(ctx(), child.EnvId).Execute()
+
+	// Wait for deletion
+	utils.Println("    Waiting for deletion to complete...")
+	rdeWaitForEnvsDeletion(client, []string{child.EnvId}, 120*time.Second)
+
+	// Re-clone from blueprint environment
+	newEnv := rdeCloneFromBlueprint(client, child, bpEnvInfo.EnvId, bpClusterId)
+	if newEnv == nil {
+		return
+	}
+
+	// Restore owner email
+	if ownerEmail != "" {
+		_ = utils.CreateEnvironmentVariable(client, child.ProjectId, newEnv.Id, rdeOwnerEmailVar, ownerEmail, false)
+	}
+
+	// Update TTL job
+	rdeUpdateTTLJob(client, newEnv.Id)
+
+	// Deploy
+	_, _, err = client.EnvironmentActionsAPI.DeployEnvironment(ctx(), newEnv.Id).Execute()
+	if err != nil {
+		utils.Println(fmt.Sprintf("    WARNING: Deploy failed after re-clone for %s: %v", name, err))
+	} else {
+		utils.Println(fmt.Sprintf("    Re-cloned and deploying %s (env: %s)", pterm.FgBlue.Sprintf("%s", name), newEnv.Id))
+	}
+}
+
+// rdeUpgradeRecloneAll upgrades multiple RDEs in parallel phases:
+// Phase 1: Delete all environments (fire all delete requests)
+// Phase 2: Wait for all deletions to complete
+// Phase 3: Re-clone all from their blueprint
+// Phase 4: Deploy all
+func rdeUpgradeRecloneAll(client *qovery.APIClient, children []rdeChildInfo) {
+	utils.Println("  WARNING: Uncommitted changes will be lost. Code in git is safe.")
+	utils.Println("")
+
+	// Pre-resolve all blueprint env IDs and cluster IDs (grouped by blueprint project ID)
+	type blueprintRef struct {
+		envId     string
+		clusterId string
+	}
+	bpRefMap := make(map[string]*blueprintRef)
+	for _, child := range children {
+		if _, ok := bpRefMap[child.BlueprintProjectId]; !ok {
+			bpEnvInfo, err := rdeFindBlueprintEnv(client, child.BlueprintProjectId)
+			if err == nil && bpEnvInfo != nil {
+				clusterId := rdeGetBlueprintClusterId(client, bpEnvInfo.EnvId)
+				bpRefMap[child.BlueprintProjectId] = &blueprintRef{
+					envId:     bpEnvInfo.EnvId,
+					clusterId: clusterId,
+				}
+			}
+		}
+	}
+
+	// Phase 1: Delete all environments
+	utils.Println("  Phase 1/4: Deleting old environments...")
+	var envIdsToWait []string
+	for _, child := range children {
+		name := strings.TrimPrefix(child.ProjectName, "rde-")
 		_, _ = client.EnvironmentMainCallsAPI.DeleteEnvironment(ctx(), child.EnvId).Execute()
-		time.Sleep(2 * time.Second)
+		envIdsToWait = append(envIdsToWait, child.EnvId)
+		utils.Println(fmt.Sprintf("    Delete requested: %s", pterm.FgBlue.Sprintf("%s", name)))
+	}
 
-		// Re-clone from blueprint
-		cloneReq := qovery.CloneEnvironmentRequest{
-			Name:      "workspace",
-			ProjectId: &child.ProjectId,
-			Mode:      qovery.ENVIRONMENTMODEENUM_DEVELOPMENT.Ptr(),
+	// Phase 2: Wait for all deletions
+	utils.Println("")
+	utils.Println("  Phase 2/4: Waiting for deletions to complete...")
+	rdeWaitForEnvsDeletion(client, envIdsToWait, 180*time.Second)
+	utils.Println("    Deletions complete.")
+
+	// Phase 3: Re-clone all from blueprint
+	utils.Println("")
+	utils.Println("  Phase 3/4: Cloning from blueprint...")
+	type cloneResult struct {
+		child  rdeChildInfo
+		newEnv *qovery.Environment
+	}
+	var results []cloneResult
+	for _, child := range children {
+		name := strings.TrimPrefix(child.ProjectName, "rde-")
+		ref, ok := bpRefMap[child.BlueprintProjectId]
+		if !ok || ref == nil {
+			utils.Println(fmt.Sprintf("    ERROR: No blueprint environment found for %s, skipping", name))
+			continue
 		}
 
-		newEnv, _, err := client.EnvironmentActionsAPI.CloneEnvironment(ctx(), child.BlueprintProjectId).
-			CloneEnvironmentRequest(cloneReq).Execute()
-		if err != nil {
-			utils.Println(fmt.Sprintf("    ERROR: Re-clone failed for %s: %v", name, err))
-			return
+		newEnv := rdeCloneFromBlueprint(client, &child, ref.envId, ref.clusterId)
+		if newEnv == nil {
+			continue
 		}
 
-		// Wait a moment for the clone to be processed, but we need the blueprint env ID, not project ID
-		// Find the blueprint environment
-		bpEnvInfo, err := rdeFindBlueprintEnv(client, child.BlueprintProjectId)
-		if err != nil || bpEnvInfo == nil {
-			utils.Println(fmt.Sprintf("    ERROR: Could not find blueprint environment for %s", name))
-			return
-		}
-
-		// Re-attempt clone from the actual blueprint environment
-		_, _ = client.EnvironmentMainCallsAPI.DeleteEnvironment(ctx(), newEnv.Id).Execute()
-		time.Sleep(1 * time.Second)
-
-		newEnv, _, err = client.EnvironmentActionsAPI.CloneEnvironment(ctx(), bpEnvInfo.EnvId).
-			CloneEnvironmentRequest(cloneReq).Execute()
-		if err != nil {
-			utils.Println(fmt.Sprintf("    ERROR: Re-clone failed for %s: %v", name, err))
-			return
+		// Restore owner email
+		if child.OwnerEmail != "" {
+			_ = utils.CreateEnvironmentVariable(client, child.ProjectId, newEnv.Id, rdeOwnerEmailVar, child.OwnerEmail, false)
 		}
 
 		// Update TTL job
 		rdeUpdateTTLJob(client, newEnv.Id)
 
-		// Deploy
-		_, _, err = client.EnvironmentActionsAPI.DeployEnvironment(ctx(), newEnv.Id).Execute()
+		results = append(results, cloneResult{child: child, newEnv: newEnv})
+		utils.Println(fmt.Sprintf("    Cloned: %s (env: %s)", pterm.FgBlue.Sprintf("%s", name), newEnv.Id))
+	}
+
+	// Phase 4: Deploy all
+	utils.Println("")
+	utils.Println("  Phase 4/4: Deploying...")
+	for _, r := range results {
+		name := strings.TrimPrefix(r.child.ProjectName, "rde-")
+		_, _, err := client.EnvironmentActionsAPI.DeployEnvironment(ctx(), r.newEnv.Id).Execute()
 		if err != nil {
-			utils.Println(fmt.Sprintf("    WARNING: Deploy failed after re-clone for %s: %v", name, err))
+			utils.Println(fmt.Sprintf("    WARNING: Deploy failed for %s: %v", name, err))
 		} else {
-			utils.Println(fmt.Sprintf("    Re-cloned and deploying: %s", newEnv.Id))
+			utils.Println(fmt.Sprintf("    Request to deploy %s has been queued..", pterm.FgBlue.Sprintf("%s", name)))
 		}
 	}
+}
+
+// rdeCloneFromBlueprint clones the blueprint environment into an RDE's project.
+func rdeCloneFromBlueprint(client *qovery.APIClient, child *rdeChildInfo, blueprintEnvId string, clusterId string) *qovery.Environment {
+	name := strings.TrimPrefix(child.ProjectName, "rde-")
+
+	cloneReq := qovery.CloneEnvironmentRequest{
+		Name:      "workspace",
+		ProjectId: &child.ProjectId,
+		Mode:      qovery.ENVIRONMENTMODEENUM_DEVELOPMENT.Ptr(),
+	}
+
+	if clusterId != "" {
+		cloneReq.ClusterId = &clusterId
+	}
+
+	newEnv, _, err := client.EnvironmentActionsAPI.CloneEnvironment(ctx(), blueprintEnvId).
+		CloneEnvironmentRequest(cloneReq).Execute()
+	if err != nil {
+		utils.Println(fmt.Sprintf("    ERROR: Re-clone failed for %s: %v", name, err))
+		return nil
+	}
+
+	return newEnv
 }
 
 func init() {
 	rdeCmd.AddCommand(rdeUpgradeCmd)
 	rdeUpgradeCmd.Flags().StringVarP(&rdeName, "name", "n", "", "RDE Name (omit to upgrade all)")
-	rdeUpgradeCmd.Flags().StringVarP(&rdeUpgradeStrategy, "strategy", "s", "image", "Upgrade strategy: 'image' (redeploy) or 'reclone' (full re-clone)")
+	rdeUpgradeCmd.Flags().StringVarP(&rdeUpgradeStrategy, "strategy", "s", "image", "Upgrade strategy: 'image' (sync source and deploy) or 'reclone' (full re-clone)")
 	rdeUpgradeCmd.Flags().StringVarP(&rdeBlueprintProjectName, "blueprint", "b", "", "Filter by Blueprint Project Name (when upgrading all)")
 	rdeUpgradeCmd.Flags().StringVarP(&organizationName, "organization", "o", "", "Organization Name")
+
+	// Sync scope flags (used with --strategy image)
+	rdeUpgradeCmd.Flags().BoolVarP(&rdeSyncAll, "sync-all", "", false, "Sync all config from blueprint (resources, ports, healthchecks, storage)")
+	rdeUpgradeCmd.Flags().BoolVarP(&rdeSyncResources, "sync-resources", "", false, "Also sync CPU, memory, and instance counts from blueprint")
+	rdeUpgradeCmd.Flags().BoolVarP(&rdeSyncPorts, "sync-ports", "", false, "Also sync port configuration from blueprint")
+	rdeUpgradeCmd.Flags().BoolVarP(&rdeSyncHealthchecks, "sync-healthchecks", "", false, "Also sync health check configuration from blueprint")
+	rdeUpgradeCmd.Flags().BoolVarP(&rdeSyncStorage, "sync-storage", "", false, "Also sync storage volumes from blueprint")
 }


### PR DESCRIPTION
## Summary

- Fix `qovery rde upgrade --strategy reclone` 404 error caused by passing a project ID to `CloneEnvironment` instead of the blueprint's environment ID
- Implement proper `--strategy image` that syncs service source/image configurations from the blueprint before deploying, instead of just redeploying with stale configs
- Add parallel execution for bulk reclone upgrades (4 phases: delete all → wait → clone all → deploy all)

## Bug Fixes

### Reclone 404 (Critical)
**Before:** `CloneEnvironment(ctx, child.BlueprintProjectId)` — passes project ID → 404
**After:** Resolves blueprint env ID via `rdeFindBlueprintEnv()` first, then `CloneEnvironment(ctx, blueprintEnvId)`

### Image strategy not syncing
**Before:** Just called `DeployEnvironment()` — re-pulls same images, ignores blueprint changes
**After:** For each service type (containers, apps, jobs, helms):
1. Lists services in blueprint and child environments
2. Matches by name
3. Updates child's source/image config from blueprint via Edit APIs (read-modify-write pattern)
4. Deploys

## New Features

### Sync scope flags (`--strategy image`)

Source/image config is **always** synced. Additional flags control what else gets synced:

| Flag | Syncs |
|---|---|
| `--sync-resources` | CPU, memory, min/max instances, autoscaling |
| `--sync-ports` | Port configuration |
| `--sync-healthchecks` | Health check configuration |
| `--sync-storage` | Storage volumes |
| `--sync-all` | All of the above |

### Parallel bulk reclone

When upgrading multiple RDEs with `--strategy reclone`:
- **Phase 1:** Fire all delete requests in parallel
- **Phase 2:** Poll until all environments return 404 (timeout: 180s)
- **Phase 3:** Clone all from blueprint
- **Phase 4:** Deploy all

### Metadata preservation on reclone

- Owner email (`RDE_OWNER_EMAIL`) is read before delete and re-set after clone
- Cluster ID defaults to blueprint's cluster

## Files Changed (3)

| File | Lines | Description |
|---|---|---|
| `cmd/rde_sync.go` | +535 | New file: sync helpers for containers, applications, jobs, helms |
| `cmd/rde_upgrade.go` | +196/-51 | Rewritten image/reclone strategies, parallel bulk upgrade |
| `cmd/rde.go` | +46 | New helpers: `rdeGetBlueprintClusterId`, `rdeIsEnvDeleted`, `rdeWaitForEnvsDeletion` |

## Testing

Tested live against Qovery API (`builder-workspaces` blueprint in `Qovery Realm`):

```
# Image strategy — syncs 2 services from blueprint
$ qovery rde upgrade --strategy image --name img-test
  Upgrading img-test (strategy: image - sync from blueprint and deploy)...
    Synced application: workspace (branch: main)
    Synced job: ttl-auto-shutdown
    Synced 2 service(s) from blueprint.
    Request to deploy img-test has been queued..

# Reclone strategy — parallel 4-phase upgrade
$ qovery rde upgrade --strategy reclone
  Phase 1/4: Deleting old environments...
    Delete requested: upgrade-1
    Delete requested: upgrade-2
  Phase 2/4: Waiting for deletions to complete...
    Deletions complete.
  Phase 3/4: Cloning from blueprint...
    Cloned: upgrade-1 (env: 49742a0d-...)
    Cloned: upgrade-2 (env: cfaee1bb-...)
  Phase 4/4: Deploying...
    Request to deploy upgrade-1 has been queued..
    Request to deploy upgrade-2 has been queued..
```