### PR TITLE
feat: add --service-id flag to qovery log command

### DIFF
--- a/cmd/log.go
+++ b/cmd/log.go
@@ -15,6 +15,7 @@ var (
 	rawFormat      bool
 	logJobName     string
 	logServiceName string
+	logServiceId   string
 )
 
 var logCmd = &cobra.Command{
@@ -43,6 +44,8 @@ func getLogs() string {
 	}
 
 	switch {
+	case logServiceId != "":
+		service = &utils.Service{ID: utils.Id(logServiceId)}
 	case applicationName != "":
 		app, err := getApplicationContextResource(client, applicationName, envID)
 		if err != nil {
@@ -126,4 +129,5 @@ func init() {
 	logCmd.Flags().StringVarP(&databaseName, "database", "d", "", "Database Name")
 	logCmd.Flags().StringVarP(&logJobName, "job", "j", "", "Job Name")
 	logCmd.Flags().StringVarP(&logServiceName, "service", "s", "", "Service Name")
+	logCmd.Flags().StringVarP(&logServiceId, "service-id", "", "", "Service ID (UUID) - skips name lookup, use when you already have the ID from a console URL")
 }


### PR DESCRIPTION
## Summary

- Adds `--service-id` flag to `qovery log` that accepts a service UUID directly
- Bypasses all name→ID API resolution (no listing of applications, containers, jobs, etc.)
- Compatible with the existing context flow — org/project/environment are still resolved normally, only the service lookup is skipped

## Motivation

When working from a Qovery console URL, the service UUID is immediately available in the path (e.g. `.../service/9243f628-0c88-440f-9c4a-39b961650b7b/service-logs`). Previously, the CLI required the service name instead, forcing an extra lookup. This flag eliminates that round-trip for agentic and scripted workflows.

## Usage

```bash
qovery log --service-id "9243f628-0c88-440f-9c4a-39b961650b7b"
```

## Test plan

- [x] Built and tested locally against a live service — logs streamed correctly with the UUID
- [x] Existing name-based flags (`--service`, `--application`, etc.) are unaffected
- [x] `--service-id` case is evaluated first in the switch, so it takes priority when provided