### PR TITLE
fix(rde): add missing PREVIEW environment type to RBAC role permissions

### DIFF
--- a/cmd/rde_create.go
+++ b/cmd/rde_create.go
@@ -276,6 +276,7 @@ func rdeSetRolePermissions(client *qovery.APIClient, orgId string, roleId string
 			devMode := qovery.ENVIRONMENTMODEENUM_DEVELOPMENT
 			stagingMode := qovery.ENVIRONMENTMODEENUM_STAGING
 			prodMode := qovery.ENVIRONMENTMODEENUM_PRODUCTION
+			previewMode := qovery.ENVIRONMENTMODEENUM_PREVIEW
 			deployerPerm := qovery.ORGANIZATIONCUSTOMROLEPROJECTPERMISSION_DEPLOYER
 			viewerPerm := qovery.ORGANIZATIONCUSTOMROLEPROJECTPERMISSION_VIEWER
 			noAccessPerm := qovery.ORGANIZATIONCUSTOMROLEPROJECTPERMISSION_NO_ACCESS
@@ -284,18 +285,21 @@ func rdeSetRolePermissions(client *qovery.APIClient, orgId string, roleId string
 				{EnvironmentType: &devMode, Permission: &deployerPerm},
 				{EnvironmentType: &stagingMode, Permission: &viewerPerm},
 				{EnvironmentType: &prodMode, Permission: &noAccessPerm},
+				{EnvironmentType: &previewMode, Permission: &deployerPerm},
 			}
 		} else {
 			// Other projects: NO_ACCESS for all
 			devMode := qovery.ENVIRONMENTMODEENUM_DEVELOPMENT
 			stagingMode := qovery.ENVIRONMENTMODEENUM_STAGING
 			prodMode := qovery.ENVIRONMENTMODEENUM_PRODUCTION
+			previewMode := qovery.ENVIRONMENTMODEENUM_PREVIEW
 			noAccessPerm := qovery.ORGANIZATIONCUSTOMROLEPROJECTPERMISSION_NO_ACCESS
 
 			permissions = []qovery.OrganizationCustomRoleUpdateRequestProjectPermissionsInnerPermissionsInner{
 				{EnvironmentType: &devMode, Permission: &noAccessPerm},
 				{EnvironmentType: &stagingMode, Permission: &noAccessPerm},
 				{EnvironmentType: &prodMode, Permission: &noAccessPerm},
+				{EnvironmentType: &previewMode, Permission: &noAccessPerm},
 			}
 		}
 


### PR DESCRIPTION
## Summary

- Fix RBAC role permission update failing during `qovery rde create` by adding the missing `PREVIEW` environment type to project permissions

## Root Cause

The `EditOrganizationCustomRole` API requires **all 4 environment types** (DEVELOPMENT, STAGING, PRODUCTION, PREVIEW) per project permission entry. The code only provided 3 -- PREVIEW was missing, causing the API to return a validation error.

## Fix

Added PREVIEW environment type to both permission blocks in `rdeSetRolePermissions`:

| Project | DEVELOPMENT | STAGING | PRODUCTION | PREVIEW (added) |
|---|---|---|---|---|
| Target (RDE project) | DEPLOYER | VIEWER | NO_ACCESS | **DEPLOYER** |
| Other projects | NO_ACCESS | NO_ACCESS | NO_ACCESS | **NO_ACCESS** |

This matches the original bash script behavior.

## Testing

Tested live against Qovery API:

```
$ qovery rde create --blueprint "builder-workspaces" --name "rbac-test" --email "alice@example.com" --skip-invite --skip-deploy
...
Step 2/6: Creating RBAC role RDE-rbac-test...
  Role: 1b95e915-f64c-499b-9d6c-6aa29370bf35    ← success, no errors
...
```

Full lifecycle verified: create with RBAC → delete (role cleaned up).