### PR TITLE
fix(helm): replace deprecated --atomic with --rollback-on-failure

### DIFF
--- a/pkg/cluster/selfmanaged/install_self_managed_cluster_service.go
+++ b/pkg/cluster/selfmanaged/install_self_managed_cluster_service.go
@@ -244,6 +244,10 @@ Qovery provides you with a default configuration that can be customized based on
 Helm values location: %s
 	`, helmValuesFileName))
 
+	utils.Println(`
+# Note: --rollback-on-failure requires Helm >= 3.15.0 (replaces the deprecated --atomic flag).
+# Check your version with: helm version`)
+
 	utils.Println(fmt.Sprintf(`
 # Install Qovery on your cluster first, without some services to avoid circular dependency errors
 helm upgrade --install --create-namespace -n qovery -f "%s" --rollback-on-failure \

--- a/pkg/cluster/selfmanaged/install_self_managed_cluster_service.go
+++ b/pkg/cluster/selfmanaged/install_self_managed_cluster_service.go
@@ -246,7 +246,7 @@ Helm values location: %s
 
 	utils.Println(fmt.Sprintf(`
 # Install Qovery on your cluster first, without some services to avoid circular dependency errors
-helm upgrade --install --create-namespace -n qovery -f "%s" --atomic \
+helm upgrade --install --create-namespace -n qovery -f "%s" --rollback-on-failure \
 	 --set services.certificates.cert-manager-configs.enabled=false \
 	 --set services.certificates.qovery-cert-manager-webhook.enabled=false \
 	 --set services.qovery.qovery-cluster-agent.enabled=false \
@@ -255,7 +255,7 @@ helm upgrade --install --create-namespace -n qovery -f "%s" --atomic \
 
 	utils.Println(fmt.Sprintf(`
 # Then, re-apply the full Qovery installation with all services
-helm upgrade --install --create-namespace -n qovery -f "%s" --wait --atomic qovery qovery/qovery
+helm upgrade --install --create-namespace -n qovery -f "%s" --wait --rollback-on-failure qovery qovery/qovery
 `, helmValuesFileName))
 	utils.Println("////////////////////////////////////////////////////////////////////////////////////")
 	utils.PrintlnInfo("Please note that the installation process may take a few minutes to complete.")


### PR DESCRIPTION
## Summary

Replace the deprecated `--atomic` flag with `--rollback-on-failure` in the helm commands generated for self-managed cluster installation.

## Changes

- `pkg/cluster/selfmanaged/install_self_managed_cluster_service.go`: replaced `--atomic` with `--rollback-on-failure` in both helm upgrade commands shown to users during BYOK cluster setup.

## Context

The `--atomic` flag has been deprecated in recent Helm versions in favor of `--rollback-on-failure`.