### PR TITLE
feat(admin): add command to update organization billing external ID

### DIFF
--- a/cmd/admin_organization_update_billing_external_id.go
+++ b/cmd/admin_organization_update_billing_external_id.go
@@ -16,11 +16,11 @@ var (
 	billingExternalId                         string
 	adminOrganizationUpdateBillingExternalId = &cobra.Command{
 		Use:   "update-billing-external-id",
-		Short: "Update the billing external ID of an organization",
-		Long: `Update the billing external ID of an organization.
+		Short: "Update the billing external ID (Chargebee subscription ID) of an organization",
+		Long: `Update the billing external ID of an organization. The billing external ID is the Chargebee subscription ID.
 
 Example:
-  qovery admin update-billing-external-id --organization-id "xxx-xxx-xxx" --billing-external-id "stripe_cus_xxx"
+  qovery admin update-billing-external-id --organization-id "xxx-xxx-xxx" --billing-external-id "AzyXZ8T0EI4jB4AZf"
 `,
 		Run: func(cmd *cobra.Command, args []string) {
 			updateOrganizationBillingExternalId()
@@ -30,7 +30,7 @@ Example:
 
 func init() {
 	adminOrganizationUpdateBillingExternalId.Flags().StringVarP(&organizationId, "organization-id", "o", "", "Organization ID (required)")
-	adminOrganizationUpdateBillingExternalId.Flags().StringVarP(&billingExternalId, "billing-external-id", "b", "", "Billing external ID (required)")
+	adminOrganizationUpdateBillingExternalId.Flags().StringVarP(&billingExternalId, "billing-external-id", "b", "", "Chargebee subscription ID (required)")
 
 	_ = adminOrganizationUpdateBillingExternalId.MarkFlagRequired("organization-id")
 	_ = adminOrganizationUpdateBillingExternalId.MarkFlagRequired("billing-external-id")

--- a/cmd/admin_organization_update_billing_external_id.go
+++ b/cmd/admin_organization_update_billing_external_id.go
@@ -1,0 +1,82 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+
+	"github.com/qovery/qovery-cli/utils"
+	"github.com/spf13/cobra"
+)
+
+var (
+	billingExternalId                         string
+	adminOrganizationUpdateBillingExternalId = &cobra.Command{
+		Use:   "update-billing-external-id",
+		Short: "Update the billing external ID of an organization",
+		Long: `Update the billing external ID of an organization.
+
+Example:
+  qovery admin update-billing-external-id --organization-id "xxx-xxx-xxx" --billing-external-id "stripe_cus_xxx"
+`,
+		Run: func(cmd *cobra.Command, args []string) {
+			updateOrganizationBillingExternalId()
+		},
+	}
+)
+
+func init() {
+	adminOrganizationUpdateBillingExternalId.Flags().StringVarP(&organizationId, "organization-id", "o", "", "Organization ID (required)")
+	adminOrganizationUpdateBillingExternalId.Flags().StringVarP(&billingExternalId, "billing-external-id", "b", "", "Billing external ID (required)")
+
+	_ = adminOrganizationUpdateBillingExternalId.MarkFlagRequired("organization-id")
+	_ = adminOrganizationUpdateBillingExternalId.MarkFlagRequired("billing-external-id")
+
+	adminCmd.AddCommand(adminOrganizationUpdateBillingExternalId)
+}
+
+func updateOrganizationBillingExternalId() {
+	tokenType, token, err := utils.GetAccessToken()
+	if err != nil {
+		utils.PrintlnError(err)
+		os.Exit(1)
+	}
+
+	type requestBody struct {
+		BillingExternalId string `json:"billing_external_id"`
+	}
+
+	bodyBytes, err := json.Marshal(requestBody{BillingExternalId: billingExternalId})
+	if err != nil {
+		utils.PrintlnError(fmt.Errorf("failed to marshal request body: %w", err))
+		os.Exit(1)
+	}
+
+	url := utils.GetAdminUrl() + "/organization/" + organizationId + "/billingExternalId"
+	req, err := http.NewRequest(http.MethodPut, url, bytes.NewBuffer(bodyBytes))
+	if err != nil {
+		utils.PrintlnError(fmt.Errorf("failed to create request: %w", err))
+		os.Exit(1)
+	}
+
+	req.Header.Set("Authorization", utils.GetAuthorizationHeaderValue(tokenType, token))
+	req.Header.Set("Content-Type", "application/json")
+
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		utils.PrintlnError(fmt.Errorf("failed to execute request: %w", err))
+		os.Exit(1)
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode >= 400 {
+		body, _ := io.ReadAll(res.Body)
+		utils.PrintlnError(fmt.Errorf("request failed (status=%d): %s", res.StatusCode, string(body)))
+		os.Exit(1)
+	}
+
+	utils.Println(fmt.Sprintf("✅ Successfully updated billing external ID for organization %s", organizationId))
+}

--- a/cmd/admin_organization_update_billing_external_id.go
+++ b/cmd/admin_organization_update_billing_external_id.go
@@ -39,6 +39,15 @@ func init() {
 }
 
 func updateOrganizationBillingExternalId() {
+	if organizationId == "" {
+		utils.PrintlnError(fmt.Errorf("organization ID is required"))
+		os.Exit(1)
+	}
+	if billingExternalId == "" {
+		utils.PrintlnError(fmt.Errorf("billing external ID is required"))
+		os.Exit(1)
+	}
+
 	tokenType, token, err := utils.GetAccessToken()
 	if err != nil {
 		utils.PrintlnError(err)

--- a/cmd/admin_organization_update_billing_external_id.go
+++ b/cmd/admin_organization_update_billing_external_id.go
@@ -70,7 +70,7 @@ func updateOrganizationBillingExternalId() {
 		utils.PrintlnError(fmt.Errorf("failed to execute request: %w", err))
 		os.Exit(1)
 	}
-	defer res.Body.Close()
+	defer func() { _ = res.Body.Close() }()
 
 	if res.StatusCode >= 400 {
 		body, _ := io.ReadAll(res.Body)


### PR DESCRIPTION
## Summary

- Adds `qovery admin update-billing-external-id` CLI command (hidden under `admin`)
- Calls `PUT /admin/organization/{orgId}/billingExternalId` with the provided external ID (Chargebee subscription)
- Both `--organization-id` and `--billing-external-id` flags are required

## Usage

```
qovery admin update-billing-external-id --organization-id "xxx-xxx-xxx" --billing-external-id "chargebee_id"
```
