### PR TITLE
feat(QOV-1954): add --ephemeral flag with clone/debug modes to qovery shell

### DIFF
--- a/cmd/shell.go
+++ b/cmd/shell.go
@@ -54,6 +54,11 @@ var shellCmd = &cobra.Command{
 
 		endpoint := "/shell/exec"
 		if ephemeral {
+			if ephemeralMode != "clone" && ephemeralMode != "debug" {
+				utils.PrintlnError(errors.New("--mode must be 'clone' or 'debug'"))
+				return
+			}
+			shellRequest.EphemeralMode = ephemeralMode
 			endpoint = "/shell/ephemeral"
 		}
 		pkg.ExecShell(shellRequest, endpoint)
@@ -65,6 +70,7 @@ var (
 	podName          string
 	podContainerName string
 	ephemeral        bool
+	ephemeralMode    string
 )
 
 func shellRequestWithContextFlags() (*pkg.ShellRequest, error) {
@@ -353,12 +359,13 @@ func init() {
 	shellCmd.Flags().StringVarP(&serviceName, "service", "", "", "Service Name")
 	shellCmd.Flags().StringVarP(&podName, "pod", "p", "", "pod name where to exec into")
 	shellCmd.Flags().StringVar(&podContainerName, "container", "", "container name inside the pod")
-	shellCmd.Flags().BoolVar(&ephemeral, "ephemeral", false, "spawn a new ephemeral pod using the service image and env vars instead of connecting to an existing pod")
+	shellCmd.Flags().BoolVar(&ephemeral, "ephemeral", false, "spawn an ephemeral shell instead of connecting to an existing pod")
+	shellCmd.Flags().StringVar(&ephemeralMode, "mode", "clone", "ephemeral mode: 'clone' (new isolated pod, Heroku-style) or 'debug' (ephemeral container injected into existing pod, kubectl-debug style)")
 	shellCmd.Example = "qovery shell\n" +
 		"qovery shell <qovery_console_service_url>\n" +
 		"qovery shell --organization <organization_name> --project <project_name> --environment <environment_name> --service <service_name>\n" +
-		"qovery shell --organization <organization_name> --project <project_name> --environment <environment_name> --service <service_name> --pod <pod_name> --container <container_name> --command <command>\n" +
-		"qovery shell --ephemeral --organization <organization_name> --project <project_name> --environment <environment_name> --service <service_name>"
+		"qovery shell --ephemeral --mode clone --organization <organization_name> --project <project_name> --environment <environment_name> --service <service_name>\n" +
+		"qovery shell --ephemeral --mode debug --organization <organization_name> --project <project_name> --environment <environment_name> --service <service_name>"
 
 	rootCmd.AddCommand(shellCmd)
 }

--- a/cmd/shell.go
+++ b/cmd/shell.go
@@ -60,6 +60,8 @@ var shellCmd = &cobra.Command{
 			}
 			shellRequest.EphemeralMode = ephemeralMode
 			endpoint = "/shell/ephemeral"
+		} else if cmd.Flags().Changed("mode") {
+			utils.PrintlnInfo("--mode has no effect without --ephemeral; ignoring it.")
 		}
 		pkg.ExecShell(shellRequest, endpoint)
 	},

--- a/cmd/shell.go
+++ b/cmd/shell.go
@@ -58,6 +58,9 @@ var shellCmd = &cobra.Command{
 				utils.PrintlnError(errors.New("--mode must be 'clone' or 'debug'"))
 				return
 			}
+			if ephemeralMode == "debug" && (cpuOverride != "" || memoryOverride != "") {
+				utils.PrintlnInfo("--cpu/--memory only apply to --mode clone; ignoring them in debug mode.")
+			}
 			shellRequest.EphemeralMode = ephemeralMode
 			shellRequest.CpuOverride = cpuOverride
 			shellRequest.MemoryOverride = memoryOverride

--- a/cmd/shell.go
+++ b/cmd/shell.go
@@ -52,7 +52,11 @@ var shellCmd = &cobra.Command{
 			return
 		}
 
-		pkg.ExecShell(shellRequest, "/shell/exec")
+		endpoint := "/shell/exec"
+		if ephemeral {
+			endpoint = "/shell/ephemeral"
+		}
+		pkg.ExecShell(shellRequest, endpoint)
 	},
 }
 
@@ -60,6 +64,7 @@ var (
 	command          []string
 	podName          string
 	podContainerName string
+	ephemeral        bool
 )
 
 func shellRequestWithContextFlags() (*pkg.ShellRequest, error) {
@@ -348,10 +353,12 @@ func init() {
 	shellCmd.Flags().StringVarP(&serviceName, "service", "", "", "Service Name")
 	shellCmd.Flags().StringVarP(&podName, "pod", "p", "", "pod name where to exec into")
 	shellCmd.Flags().StringVar(&podContainerName, "container", "", "container name inside the pod")
+	shellCmd.Flags().BoolVar(&ephemeral, "ephemeral", false, "spawn a new ephemeral pod using the service image and env vars instead of connecting to an existing pod")
 	shellCmd.Example = "qovery shell\n" +
 		"qovery shell <qovery_console_service_url>\n" +
 		"qovery shell --organization <organization_name> --project <project_name> --environment <environment_name> --service <service_name>\n" +
-		"qovery shell --organization <organization_name> --project <project_name> --environment <environment_name> --service <service_name> --pod <pod_name> --container <container_name> --command <command>"
+		"qovery shell --organization <organization_name> --project <project_name> --environment <environment_name> --service <service_name> --pod <pod_name> --container <container_name> --command <command>\n" +
+		"qovery shell --ephemeral --organization <organization_name> --project <project_name> --environment <environment_name> --service <service_name>"
 
 	rootCmd.AddCommand(shellCmd)
 }

--- a/cmd/shell.go
+++ b/cmd/shell.go
@@ -59,6 +59,8 @@ var shellCmd = &cobra.Command{
 				return
 			}
 			shellRequest.EphemeralMode = ephemeralMode
+			shellRequest.CpuOverride = cpuOverride
+			shellRequest.MemoryOverride = memoryOverride
 			endpoint = "/shell/ephemeral"
 		} else if cmd.Flags().Changed("mode") {
 			utils.PrintlnInfo("--mode has no effect without --ephemeral; ignoring it.")
@@ -73,6 +75,8 @@ var (
 	podContainerName string
 	ephemeral        bool
 	ephemeralMode    string
+	cpuOverride      string
+	memoryOverride   string
 )
 
 func shellRequestWithContextFlags() (*pkg.ShellRequest, error) {
@@ -363,10 +367,13 @@ func init() {
 	shellCmd.Flags().StringVar(&podContainerName, "container", "", "container name inside the pod")
 	shellCmd.Flags().BoolVar(&ephemeral, "ephemeral", false, "spawn an ephemeral shell instead of connecting to an existing pod")
 	shellCmd.Flags().StringVar(&ephemeralMode, "mode", "clone", "ephemeral mode: 'clone' (new isolated pod, Heroku-style) or 'debug' (ephemeral container injected into existing pod, kubectl-debug style)")
+	shellCmd.Flags().StringVar(&cpuOverride, "cpu", "", "override CPU request+limit for the ephemeral pod (e.g. '500m', '2')")
+	shellCmd.Flags().StringVar(&memoryOverride, "memory", "", "override memory request+limit for the ephemeral pod (e.g. '512Mi', '2Gi')")
 	shellCmd.Example = "qovery shell\n" +
 		"qovery shell <qovery_console_service_url>\n" +
 		"qovery shell --organization <organization_name> --project <project_name> --environment <environment_name> --service <service_name>\n" +
 		"qovery shell --ephemeral --mode clone --organization <organization_name> --project <project_name> --environment <environment_name> --service <service_name>\n" +
+		"qovery shell --ephemeral --mode clone --memory 2Gi --organization <organization_name> --project <project_name> --environment <environment_name> --service <service_name>\n" +
 		"qovery shell --ephemeral --mode debug --organization <organization_name> --project <project_name> --environment <environment_name> --service <service_name>"
 
 	rootCmd.AddCommand(shellCmd)

--- a/pkg/shell.go
+++ b/pkg/shell.go
@@ -47,6 +47,8 @@ type ShellRequest struct {
 	TtyWidth       uint16   `url:"tty_width"`
 	TtyHeight      uint16   `url:"tty_height"`
 	EphemeralMode  string   `url:"mode,omitempty"`
+	CpuOverride    string   `url:"cpu_override,omitempty"`
+	MemoryOverride string   `url:"memory_override,omitempty"`
 }
 
 func (s *ShellRequest) SetTtySize(width uint16, height uint16) {

--- a/pkg/shell.go
+++ b/pkg/shell.go
@@ -46,6 +46,7 @@ type ShellRequest struct {
 	Command        []string `url:"command"`
 	TtyWidth       uint16   `url:"tty_width"`
 	TtyHeight      uint16   `url:"tty_height"`
+	EphemeralMode  string   `url:"mode,omitempty"`
 }
 
 func (s *ShellRequest) SetTtySize(width uint16, height uint16) {


### PR DESCRIPTION
Jira: https://qovery.atlassian.net/browse/QOV-1954

## Summary

- Adds `--ephemeral` flag to `qovery shell`
- Adds `--mode` flag (`clone` or `debug`) to control the ephemeral behavior
- Adds `--cpu` and `--memory` flags to override resource limits on the clone pod
- `--mode clone` (default): spawns a new isolated pod from the service image (Heroku-style, HIPAA-safe)
- `--mode debug`: injects an ephemeral container into an existing running pod (kubectl-debug style, shares network/PID namespace)
- Warning printed if `--mode` is set without `--ephemeral`

## Usage

```bash
# Normal shell (existing behavior)
qovery shell

# Ephemeral shell -- clone mode (new isolated pod)
qovery shell --ephemeral --mode clone \
  --organization myorg --project myproject --environment myenv --service myservice

# With resource override -- useful for Rails migrations or any job needing more headroom
qovery shell --ephemeral --mode clone --memory 2Gi --cpu 1 \
  --organization myorg --project myproject --environment myenv --service myservice

# Debug mode (inject into existing pod)
qovery shell --ephemeral --mode debug \
  --organization myorg --project myproject --environment myenv --service myservice

# Custom command
qovery shell --ephemeral --mode clone --command python,manage.py,shell_plus \
  --organization myorg --project myproject --environment myenv --service myservice

# Via console URL
qovery shell --ephemeral --mode clone <qovery_console_service_url>
```

## Depends on

rust-backend MR !635 must be merged and deployed first: https://gitlab.com/qovery/backend/rust-backend/-/merge_requests/635

## Test plan

- [ ] `qovery shell` (no flag) -- verify existing behavior unchanged
- [ ] `qovery shell --ephemeral --mode clone` -- verify new pod spawns and is deleted on exit
- [ ] `qovery shell --ephemeral --mode clone` -- pod deleted on Ctrl+C
- [ ] `qovery shell --ephemeral --mode clone --memory 2Gi` -- verify pod starts with overridden memory
- [ ] `qovery shell --ephemeral --mode debug` -- verify ephemeral container injected into existing pod
- [ ] `qovery shell --ephemeral --mode clone --command python,manage.py,shell_plus` -- custom command
- [ ] `qovery shell --mode clone` (without --ephemeral) -- verify warning printed, normal shell opened
- [ ] Via console URL with `--ephemeral --mode clone`