### PR TITLE
feat(qov-1986) Set secret manager access name instead of id

### DIFF
--- a/cmd/admin_organization_transfer_ownership.go
+++ b/cmd/admin_organization_transfer_ownership.go
@@ -13,9 +13,9 @@ import (
 )
 
 var (
-	newOwnerUserId                      string
-	newOwnerEmail                       string
-	authProvider                        string
+	newOwnerUserId                     string
+	newOwnerEmail                      string
+	authProvider                       string
 	adminTransferOrganizationOwnership = &cobra.Command{
 		Use:   "transfer-ownership",
 		Short: "Transfer organization ownership to another user",
@@ -130,6 +130,7 @@ func transferOrganizationOwnership() {
 			if foundMember == nil {
 				utils.PrintlnError(fmt.Errorf("no member found with email '%s' and provider '%s'", newOwnerEmail, authProvider))
 				os.Exit(1)
+				panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 			}
 
 			targetUserId = foundMember.Id

--- a/cmd/application_external_secret_create.go
+++ b/cmd/application_external_secret_create.go
@@ -25,7 +25,7 @@ var applicationExternalSecretCreateCmd = &cobra.Command{
 		}
 
 		client := utils.GetQoveryClient(tokenType, token)
-		_, projectId, envId, err := getOrganizationProjectEnvironmentContextResourcesIds(client)
+		organizationId, projectId, envId, err := getOrganizationProjectEnvironmentContextResourcesIds(client)
 
 		if err != nil {
 			utils.PrintlnError(err)
@@ -50,7 +50,14 @@ var applicationExternalSecretCreateCmd = &cobra.Command{
 			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
-		err = utils.CreateServiceExternalSecret(client, projectId, envId, application.Id, utils.ApplicationScope, utils.Key, utils.Reference, utils.SecretManagerAccessId, utils.MountPath)
+		secretManagerAccessId, err := getSecretManagerAccessIdByName(client, organizationId, envId, utils.SecretManagerAccessName)
+		if err != nil {
+			utils.PrintlnError(err)
+			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
+		}
+
+		err = utils.CreateServiceExternalSecret(client, projectId, envId, application.Id, utils.ApplicationScope, utils.Key, utils.Reference, secretManagerAccessId, utils.MountPath)
 
 		if err != nil {
 			utils.PrintlnError(err)
@@ -70,12 +77,12 @@ func init() {
 	applicationExternalSecretCreateCmd.Flags().StringVarP(&applicationName, "application", "n", "", "Application Name")
 	applicationExternalSecretCreateCmd.Flags().StringVarP(&utils.Key, "key", "k", "", "External secret key")
 	applicationExternalSecretCreateCmd.Flags().StringVarP(&utils.Reference, "reference", "r", "", "Reference to the secret in the secrets provider")
-	applicationExternalSecretCreateCmd.Flags().StringVarP(&utils.SecretManagerAccessId, "secret-manager-access-id", "", "", "Secret manager access ID")
+	applicationExternalSecretCreateCmd.Flags().StringVarP(&utils.SecretManagerAccessName, "secret-manager-access-name", "", "", "Secret manager access name")
 	applicationExternalSecretCreateCmd.Flags().StringVarP(&utils.ApplicationScope, "scope", "", "APPLICATION", "Scope of this external secret <PROJECT|ENVIRONMENT|APPLICATION>")
 	applicationExternalSecretCreateCmd.Flags().StringVarP(&utils.MountPath, "mount-path", "", "", "Path where the secret will be mounted as a file")
 
 	_ = applicationExternalSecretCreateCmd.MarkFlagRequired("key")
 	_ = applicationExternalSecretCreateCmd.MarkFlagRequired("reference")
-	_ = applicationExternalSecretCreateCmd.MarkFlagRequired("secret-manager-access-id")
+	_ = applicationExternalSecretCreateCmd.MarkFlagRequired("secret-manager-access-name")
 	_ = applicationExternalSecretCreateCmd.MarkFlagRequired("application")
 }

--- a/cmd/application_external_secret_update.go
+++ b/cmd/application_external_secret_update.go
@@ -25,7 +25,7 @@ var applicationExternalSecretUpdateCmd = &cobra.Command{
 		}
 
 		client := utils.GetQoveryClient(tokenType, token)
-		_, _, envId, err := getOrganizationProjectEnvironmentContextResourcesIds(client)
+		organizationId, _, envId, err := getOrganizationProjectEnvironmentContextResourcesIds(client)
 
 		if err != nil {
 			utils.PrintlnError(err)
@@ -50,7 +50,14 @@ var applicationExternalSecretUpdateCmd = &cobra.Command{
 			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
-		err = utils.UpdateServiceExternalSecret(client, utils.Key, utils.Reference, utils.SecretManagerAccessId, application.Id, utils.ApplicationType)
+		secretManagerAccessId, err := getSecretManagerAccessIdByName(client, organizationId, envId, utils.SecretManagerAccessName)
+		if err != nil {
+			utils.PrintlnError(err)
+			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
+		}
+
+		err = utils.UpdateServiceExternalSecret(client, utils.Key, utils.Reference, secretManagerAccessId, application.Id, utils.ApplicationType)
 
 		if err != nil {
 			utils.PrintlnError(err)
@@ -70,7 +77,7 @@ func init() {
 	applicationExternalSecretUpdateCmd.Flags().StringVarP(&applicationName, "application", "n", "", "Application Name")
 	applicationExternalSecretUpdateCmd.Flags().StringVarP(&utils.Key, "key", "k", "", "External secret key")
 	applicationExternalSecretUpdateCmd.Flags().StringVarP(&utils.Reference, "reference", "r", "", "New reference to the secret in the secrets provider")
-	applicationExternalSecretUpdateCmd.Flags().StringVarP(&utils.SecretManagerAccessId, "secret-manager-access-id", "", "", "New secret manager access ID")
+	applicationExternalSecretUpdateCmd.Flags().StringVarP(&utils.SecretManagerAccessName, "secret-manager-access-name", "", "", "New secret manager access name")
 
 	_ = applicationExternalSecretUpdateCmd.MarkFlagRequired("key")
 	_ = applicationExternalSecretUpdateCmd.MarkFlagRequired("application")

--- a/cmd/container_external_secret_create.go
+++ b/cmd/container_external_secret_create.go
@@ -25,7 +25,7 @@ var containerExternalSecretCreateCmd = &cobra.Command{
 		}
 
 		client := utils.GetQoveryClient(tokenType, token)
-		_, projectId, envId, err := getOrganizationProjectEnvironmentContextResourcesIds(client)
+		organizationId, projectId, envId, err := getOrganizationProjectEnvironmentContextResourcesIds(client)
 
 		if err != nil {
 			utils.PrintlnError(err)
@@ -50,7 +50,14 @@ var containerExternalSecretCreateCmd = &cobra.Command{
 			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
-		err = utils.CreateServiceExternalSecret(client, projectId, envId, container.Id, utils.ContainerScope, utils.Key, utils.Reference, utils.SecretManagerAccessId, utils.MountPath)
+		secretManagerAccessId, err := getSecretManagerAccessIdByName(client, organizationId, envId, utils.SecretManagerAccessName)
+		if err != nil {
+			utils.PrintlnError(err)
+			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
+		}
+
+		err = utils.CreateServiceExternalSecret(client, projectId, envId, container.Id, utils.ContainerScope, utils.Key, utils.Reference, secretManagerAccessId, utils.MountPath)
 
 		if err != nil {
 			utils.PrintlnError(err)
@@ -70,12 +77,12 @@ func init() {
 	containerExternalSecretCreateCmd.Flags().StringVarP(&containerName, "container", "n", "", "Container Name")
 	containerExternalSecretCreateCmd.Flags().StringVarP(&utils.Key, "key", "k", "", "External secret key")
 	containerExternalSecretCreateCmd.Flags().StringVarP(&utils.Reference, "reference", "r", "", "Reference to the secret in the secrets provider")
-	containerExternalSecretCreateCmd.Flags().StringVarP(&utils.SecretManagerAccessId, "secret-manager-access-id", "", "", "Secret manager access ID")
+	containerExternalSecretCreateCmd.Flags().StringVarP(&utils.SecretManagerAccessName, "secret-manager-access-name", "", "", "Secret manager access name")
 	containerExternalSecretCreateCmd.Flags().StringVarP(&utils.ContainerScope, "scope", "", "CONTAINER", "Scope of this external secret <PROJECT|ENVIRONMENT|CONTAINER>")
 	containerExternalSecretCreateCmd.Flags().StringVarP(&utils.MountPath, "mount-path", "", "", "Path where the secret will be mounted as a file")
 
 	_ = containerExternalSecretCreateCmd.MarkFlagRequired("key")
 	_ = containerExternalSecretCreateCmd.MarkFlagRequired("reference")
-	_ = containerExternalSecretCreateCmd.MarkFlagRequired("secret-manager-access-id")
+	_ = containerExternalSecretCreateCmd.MarkFlagRequired("secret-manager-access-name")
 	_ = containerExternalSecretCreateCmd.MarkFlagRequired("container")
 }

--- a/cmd/container_external_secret_update.go
+++ b/cmd/container_external_secret_update.go
@@ -25,7 +25,7 @@ var containerExternalSecretUpdateCmd = &cobra.Command{
 		}
 
 		client := utils.GetQoveryClient(tokenType, token)
-		_, _, envId, err := getOrganizationProjectEnvironmentContextResourcesIds(client)
+		organizationId, _, envId, err := getOrganizationProjectEnvironmentContextResourcesIds(client)
 
 		if err != nil {
 			utils.PrintlnError(err)
@@ -50,7 +50,14 @@ var containerExternalSecretUpdateCmd = &cobra.Command{
 			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
-		err = utils.UpdateServiceExternalSecret(client, utils.Key, utils.Reference, utils.SecretManagerAccessId, container.Id, utils.ContainerType)
+		secretManagerAccessId, err := getSecretManagerAccessIdByName(client, organizationId, envId, utils.SecretManagerAccessName)
+		if err != nil {
+			utils.PrintlnError(err)
+			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
+		}
+
+		err = utils.UpdateServiceExternalSecret(client, utils.Key, utils.Reference, secretManagerAccessId, container.Id, utils.ContainerType)
 
 		if err != nil {
 			utils.PrintlnError(err)
@@ -70,7 +77,7 @@ func init() {
 	containerExternalSecretUpdateCmd.Flags().StringVarP(&containerName, "container", "n", "", "Container Name")
 	containerExternalSecretUpdateCmd.Flags().StringVarP(&utils.Key, "key", "k", "", "External secret key")
 	containerExternalSecretUpdateCmd.Flags().StringVarP(&utils.Reference, "reference", "r", "", "New reference to the secret in the secrets provider")
-	containerExternalSecretUpdateCmd.Flags().StringVarP(&utils.SecretManagerAccessId, "secret-manager-access-id", "", "", "New secret manager access ID")
+	containerExternalSecretUpdateCmd.Flags().StringVarP(&utils.SecretManagerAccessName, "secret-manager-access-name", "", "", "New secret manager access name")
 
 	_ = containerExternalSecretUpdateCmd.MarkFlagRequired("key")
 	_ = containerExternalSecretUpdateCmd.MarkFlagRequired("container")

--- a/cmd/cronjob_external_secret_create.go
+++ b/cmd/cronjob_external_secret_create.go
@@ -25,7 +25,7 @@ var cronjobExternalSecretCreateCmd = &cobra.Command{
 		}
 
 		client := utils.GetQoveryClient(tokenType, token)
-		_, projectId, envId, err := getOrganizationProjectEnvironmentContextResourcesIds(client)
+		organizationId, projectId, envId, err := getOrganizationProjectEnvironmentContextResourcesIds(client)
 
 		if err != nil {
 			utils.PrintlnError(err)
@@ -50,7 +50,14 @@ var cronjobExternalSecretCreateCmd = &cobra.Command{
 			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
-		err = utils.CreateServiceExternalSecret(client, projectId, envId, cronjob.CronJobResponse.Id, utils.JobScope, utils.Key, utils.Reference, utils.SecretManagerAccessId, utils.MountPath)
+		secretManagerAccessId, err := getSecretManagerAccessIdByName(client, organizationId, envId, utils.SecretManagerAccessName)
+		if err != nil {
+			utils.PrintlnError(err)
+			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
+		}
+
+		err = utils.CreateServiceExternalSecret(client, projectId, envId, cronjob.CronJobResponse.Id, utils.JobScope, utils.Key, utils.Reference, secretManagerAccessId, utils.MountPath)
 
 		if err != nil {
 			utils.PrintlnError(err)
@@ -70,12 +77,12 @@ func init() {
 	cronjobExternalSecretCreateCmd.Flags().StringVarP(&cronjobName, "cronjob", "n", "", "Cronjob Name")
 	cronjobExternalSecretCreateCmd.Flags().StringVarP(&utils.Key, "key", "k", "", "External secret key")
 	cronjobExternalSecretCreateCmd.Flags().StringVarP(&utils.Reference, "reference", "r", "", "Reference to the secret in the secrets provider")
-	cronjobExternalSecretCreateCmd.Flags().StringVarP(&utils.SecretManagerAccessId, "secret-manager-access-id", "", "", "Secret manager access ID")
+	cronjobExternalSecretCreateCmd.Flags().StringVarP(&utils.SecretManagerAccessName, "secret-manager-access-name", "", "", "Secret manager access name")
 	cronjobExternalSecretCreateCmd.Flags().StringVarP(&utils.JobScope, "scope", "", "JOB", "Scope of this external secret <PROJECT|ENVIRONMENT|JOB>")
 	cronjobExternalSecretCreateCmd.Flags().StringVarP(&utils.MountPath, "mount-path", "", "", "Path where the secret will be mounted as a file")
 
 	_ = cronjobExternalSecretCreateCmd.MarkFlagRequired("key")
 	_ = cronjobExternalSecretCreateCmd.MarkFlagRequired("reference")
-	_ = cronjobExternalSecretCreateCmd.MarkFlagRequired("secret-manager-access-id")
+	_ = cronjobExternalSecretCreateCmd.MarkFlagRequired("secret-manager-access-name")
 	_ = cronjobExternalSecretCreateCmd.MarkFlagRequired("cronjob")
 }

--- a/cmd/cronjob_external_secret_update.go
+++ b/cmd/cronjob_external_secret_update.go
@@ -25,7 +25,7 @@ var cronjobExternalSecretUpdateCmd = &cobra.Command{
 		}
 
 		client := utils.GetQoveryClient(tokenType, token)
-		_, _, envId, err := getOrganizationProjectEnvironmentContextResourcesIds(client)
+		organizationId, _, envId, err := getOrganizationProjectEnvironmentContextResourcesIds(client)
 
 		if err != nil {
 			utils.PrintlnError(err)
@@ -50,7 +50,14 @@ var cronjobExternalSecretUpdateCmd = &cobra.Command{
 			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
-		err = utils.UpdateServiceExternalSecret(client, utils.Key, utils.Reference, utils.SecretManagerAccessId, cronjob.CronJobResponse.Id, utils.JobType)
+		secretManagerAccessId, err := getSecretManagerAccessIdByName(client, organizationId, envId, utils.SecretManagerAccessName)
+		if err != nil {
+			utils.PrintlnError(err)
+			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
+		}
+
+		err = utils.UpdateServiceExternalSecret(client, utils.Key, utils.Reference, secretManagerAccessId, cronjob.CronJobResponse.Id, utils.JobType)
 
 		if err != nil {
 			utils.PrintlnError(err)
@@ -70,7 +77,7 @@ func init() {
 	cronjobExternalSecretUpdateCmd.Flags().StringVarP(&cronjobName, "cronjob", "n", "", "Cronjob Name")
 	cronjobExternalSecretUpdateCmd.Flags().StringVarP(&utils.Key, "key", "k", "", "External secret key")
 	cronjobExternalSecretUpdateCmd.Flags().StringVarP(&utils.Reference, "reference", "r", "", "New reference to the secret in the secrets provider")
-	cronjobExternalSecretUpdateCmd.Flags().StringVarP(&utils.SecretManagerAccessId, "secret-manager-access-id", "", "", "New secret manager access ID")
+	cronjobExternalSecretUpdateCmd.Flags().StringVarP(&utils.SecretManagerAccessName, "secret-manager-access-name", "", "", "New secret manager access name")
 
 	_ = cronjobExternalSecretUpdateCmd.MarkFlagRequired("key")
 	_ = cronjobExternalSecretUpdateCmd.MarkFlagRequired("cronjob")

--- a/cmd/environment_external_secret_create.go
+++ b/cmd/environment_external_secret_create.go
@@ -47,7 +47,10 @@ var environmentExternalSecretCreateCmd = &cobra.Command{
 			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
-		err = utils.CreateServiceExternalSecret(client, project.Id, environment.Id, "", utils.EnvironmentScope, utils.Key, utils.Reference, utils.SecretManagerAccessId, utils.MountPath)
+		secretManagerAccessId, err := getSecretManagerAccessIdByName(client, organizationId, environment.Id, utils.SecretManagerAccessName)
+		checkError(err)
+
+		err = utils.CreateServiceExternalSecret(client, project.Id, environment.Id, "", utils.EnvironmentScope, utils.Key, utils.Reference, secretManagerAccessId, utils.MountPath)
 		checkError(err)
 
 		utils.Println(fmt.Sprintf("External secret %s has been created", pterm.FgBlue.Sprintf("%s", utils.Key)))
@@ -61,7 +64,7 @@ func init() {
 	environmentExternalSecretCreateCmd.Flags().StringVarP(&environmentName, "environment", "", "", "Environment Name")
 	environmentExternalSecretCreateCmd.Flags().StringVarP(&utils.Key, "key", "k", "", "External secret key")
 	environmentExternalSecretCreateCmd.Flags().StringVarP(&utils.Reference, "reference", "r", "", "Reference to the secret in the secrets provider")
-	environmentExternalSecretCreateCmd.Flags().StringVarP(&utils.SecretManagerAccessId, "secret-manager-access-id", "", "", "Secret manager access ID")
+	environmentExternalSecretCreateCmd.Flags().StringVarP(&utils.SecretManagerAccessName, "secret-manager-access-name", "", "", "Secret manager access name")
 	environmentExternalSecretCreateCmd.Flags().StringVarP(&utils.EnvironmentScope, "scope", "", "ENVIRONMENT", "Scope of this external secret <PROJECT|ENVIRONMENT>")
 	environmentExternalSecretCreateCmd.Flags().StringVarP(&utils.MountPath, "mount-path", "", "", "Path where the secret will be mounted as a file")
 
@@ -69,5 +72,5 @@ func init() {
 	_ = environmentExternalSecretCreateCmd.MarkFlagRequired("environment")
 	_ = environmentExternalSecretCreateCmd.MarkFlagRequired("key")
 	_ = environmentExternalSecretCreateCmd.MarkFlagRequired("reference")
-	_ = environmentExternalSecretCreateCmd.MarkFlagRequired("secret-manager-access-id")
+	_ = environmentExternalSecretCreateCmd.MarkFlagRequired("secret-manager-access-name")
 }

--- a/cmd/environment_external_secret_update.go
+++ b/cmd/environment_external_secret_update.go
@@ -47,7 +47,10 @@ var environmentExternalSecretUpdateCmd = &cobra.Command{
 			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
-		err = utils.UpdateEnvironmentExternalSecret(client, environment.Id, utils.Key, utils.Reference, utils.SecretManagerAccessId)
+		secretManagerAccessId, err := getSecretManagerAccessIdByName(client, organizationId, environment.Id, utils.SecretManagerAccessName)
+		checkError(err)
+
+		err = utils.UpdateEnvironmentExternalSecret(client, environment.Id, utils.Key, utils.Reference, secretManagerAccessId)
 		checkError(err)
 
 		utils.Println(fmt.Sprintf("External secret %s has been updated", pterm.FgBlue.Sprintf("%s", utils.Key)))
@@ -61,7 +64,7 @@ func init() {
 	environmentExternalSecretUpdateCmd.Flags().StringVarP(&environmentName, "environment", "", "", "Environment Name")
 	environmentExternalSecretUpdateCmd.Flags().StringVarP(&utils.Key, "key", "k", "", "External secret key")
 	environmentExternalSecretUpdateCmd.Flags().StringVarP(&utils.Reference, "reference", "r", "", "New reference to the secret in the secrets provider")
-	environmentExternalSecretUpdateCmd.Flags().StringVarP(&utils.SecretManagerAccessId, "secret-manager-access-id", "", "", "New secret manager access ID")
+	environmentExternalSecretUpdateCmd.Flags().StringVarP(&utils.SecretManagerAccessName, "secret-manager-access-name", "", "", "New secret manager access name")
 
 	_ = environmentExternalSecretUpdateCmd.MarkFlagRequired("project")
 	_ = environmentExternalSecretUpdateCmd.MarkFlagRequired("environment")

--- a/cmd/external_secret_helpers.go
+++ b/cmd/external_secret_helpers.go
@@ -1,0 +1,40 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/qovery/qovery-client-go"
+	"github.com/qovery/qovery-cli/pkg/cluster"
+	"github.com/qovery/qovery-cli/pkg/promptuifactory"
+)
+
+func getSecretManagerAccessIdByName(client *qovery.APIClient, organizationId, envId, name string) (string, error) {
+	env, _, err := client.EnvironmentMainCallsAPI.GetEnvironment(context.Background(), envId).Execute()
+	if err != nil {
+		return "", fmt.Errorf("failed to get environment: %w", err)
+	}
+
+	clusters, err := cluster.NewClusterService(client, &promptuifactory.PromptUiFactoryImpl{}).ListClusters(organizationId)
+	if err != nil {
+		return "", fmt.Errorf("failed to list clusters: %w", err)
+	}
+
+	var matchedCluster *qovery.Cluster
+	for i, c := range clusters.GetResults() {
+		if c.Id == env.ClusterId {
+			matchedCluster = &clusters.GetResults()[i]
+			break
+		}
+	}
+	if matchedCluster == nil {
+		return "", fmt.Errorf("cluster %s not found in organization", env.ClusterId)
+	}
+
+	for _, sma := range matchedCluster.SecretManagerAccesses {
+		if sma.Name == name {
+			return sma.Id, nil
+		}
+	}
+	return "", fmt.Errorf("secret manager access %q not found in cluster %s", name, matchedCluster.Name)
+}

--- a/cmd/helm_external_secret_create.go
+++ b/cmd/helm_external_secret_create.go
@@ -25,7 +25,7 @@ var helmExternalSecretCreateCmd = &cobra.Command{
 		}
 
 		client := utils.GetQoveryClient(tokenType, token)
-		_, projectId, envId, err := getOrganizationProjectEnvironmentContextResourcesIds(client)
+		organizationId, projectId, envId, err := getOrganizationProjectEnvironmentContextResourcesIds(client)
 
 		if err != nil {
 			utils.PrintlnError(err)
@@ -50,7 +50,14 @@ var helmExternalSecretCreateCmd = &cobra.Command{
 			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
-		err = utils.CreateServiceExternalSecret(client, projectId, envId, helm.Id, utils.HelmScope, utils.Key, utils.Reference, utils.SecretManagerAccessId, utils.MountPath)
+		secretManagerAccessId, err := getSecretManagerAccessIdByName(client, organizationId, envId, utils.SecretManagerAccessName)
+		if err != nil {
+			utils.PrintlnError(err)
+			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
+		}
+
+		err = utils.CreateServiceExternalSecret(client, projectId, envId, helm.Id, utils.HelmScope, utils.Key, utils.Reference, secretManagerAccessId, utils.MountPath)
 
 		if err != nil {
 			utils.PrintlnError(err)
@@ -70,12 +77,12 @@ func init() {
 	helmExternalSecretCreateCmd.Flags().StringVarP(&helmName, "helm", "n", "", "Helm Name")
 	helmExternalSecretCreateCmd.Flags().StringVarP(&utils.Key, "key", "k", "", "External secret key")
 	helmExternalSecretCreateCmd.Flags().StringVarP(&utils.Reference, "reference", "r", "", "Reference to the secret in the secrets provider")
-	helmExternalSecretCreateCmd.Flags().StringVarP(&utils.SecretManagerAccessId, "secret-manager-access-id", "", "", "Secret manager access ID")
+	helmExternalSecretCreateCmd.Flags().StringVarP(&utils.SecretManagerAccessName, "secret-manager-access-name", "", "", "Secret manager access name")
 	helmExternalSecretCreateCmd.Flags().StringVarP(&utils.HelmScope, "scope", "", "HELM", "Scope of this external secret <PROJECT|ENVIRONMENT|HELM>")
 	helmExternalSecretCreateCmd.Flags().StringVarP(&utils.MountPath, "mount-path", "", "", "Path where the secret will be mounted as a file")
 
 	_ = helmExternalSecretCreateCmd.MarkFlagRequired("key")
 	_ = helmExternalSecretCreateCmd.MarkFlagRequired("reference")
-	_ = helmExternalSecretCreateCmd.MarkFlagRequired("secret-manager-access-id")
+	_ = helmExternalSecretCreateCmd.MarkFlagRequired("secret-manager-access-name")
 	_ = helmExternalSecretCreateCmd.MarkFlagRequired("helm")
 }

--- a/cmd/helm_external_secret_update.go
+++ b/cmd/helm_external_secret_update.go
@@ -25,7 +25,7 @@ var helmExternalSecretUpdateCmd = &cobra.Command{
 		}
 
 		client := utils.GetQoveryClient(tokenType, token)
-		_, _, envId, err := getOrganizationProjectEnvironmentContextResourcesIds(client)
+		organizationId, _, envId, err := getOrganizationProjectEnvironmentContextResourcesIds(client)
 
 		if err != nil {
 			utils.PrintlnError(err)
@@ -50,7 +50,14 @@ var helmExternalSecretUpdateCmd = &cobra.Command{
 			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
-		err = utils.UpdateServiceExternalSecret(client, utils.Key, utils.Reference, utils.SecretManagerAccessId, helm.Id, utils.HelmType)
+		secretManagerAccessId, err := getSecretManagerAccessIdByName(client, organizationId, envId, utils.SecretManagerAccessName)
+		if err != nil {
+			utils.PrintlnError(err)
+			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
+		}
+
+		err = utils.UpdateServiceExternalSecret(client, utils.Key, utils.Reference, secretManagerAccessId, helm.Id, utils.HelmType)
 
 		if err != nil {
 			utils.PrintlnError(err)
@@ -70,7 +77,7 @@ func init() {
 	helmExternalSecretUpdateCmd.Flags().StringVarP(&helmName, "helm", "n", "", "Helm Name")
 	helmExternalSecretUpdateCmd.Flags().StringVarP(&utils.Key, "key", "k", "", "External secret key")
 	helmExternalSecretUpdateCmd.Flags().StringVarP(&utils.Reference, "reference", "r", "", "New reference to the secret in the secrets provider")
-	helmExternalSecretUpdateCmd.Flags().StringVarP(&utils.SecretManagerAccessId, "secret-manager-access-id", "", "", "New secret manager access ID")
+	helmExternalSecretUpdateCmd.Flags().StringVarP(&utils.SecretManagerAccessName, "secret-manager-access-name", "", "", "New secret manager access name")
 
 	_ = helmExternalSecretUpdateCmd.MarkFlagRequired("key")
 	_ = helmExternalSecretUpdateCmd.MarkFlagRequired("helm")

--- a/cmd/lifecycle_external_secret_create.go
+++ b/cmd/lifecycle_external_secret_create.go
@@ -25,7 +25,7 @@ var lifecycleExternalSecretCreateCmd = &cobra.Command{
 		}
 
 		client := utils.GetQoveryClient(tokenType, token)
-		_, projectId, envId, err := getOrganizationProjectEnvironmentContextResourcesIds(client)
+		organizationId, projectId, envId, err := getOrganizationProjectEnvironmentContextResourcesIds(client)
 
 		if err != nil {
 			utils.PrintlnError(err)
@@ -50,7 +50,14 @@ var lifecycleExternalSecretCreateCmd = &cobra.Command{
 			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
-		err = utils.CreateServiceExternalSecret(client, projectId, envId, lifecycle.LifecycleJobResponse.Id, utils.JobScope, utils.Key, utils.Reference, utils.SecretManagerAccessId, utils.MountPath)
+		secretManagerAccessId, err := getSecretManagerAccessIdByName(client, organizationId, envId, utils.SecretManagerAccessName)
+		if err != nil {
+			utils.PrintlnError(err)
+			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
+		}
+
+		err = utils.CreateServiceExternalSecret(client, projectId, envId, lifecycle.LifecycleJobResponse.Id, utils.JobScope, utils.Key, utils.Reference, secretManagerAccessId, utils.MountPath)
 
 		if err != nil {
 			utils.PrintlnError(err)
@@ -70,12 +77,12 @@ func init() {
 	lifecycleExternalSecretCreateCmd.Flags().StringVarP(&lifecycleName, "lifecycle", "n", "", "Lifecycle Name")
 	lifecycleExternalSecretCreateCmd.Flags().StringVarP(&utils.Key, "key", "k", "", "External secret key")
 	lifecycleExternalSecretCreateCmd.Flags().StringVarP(&utils.Reference, "reference", "r", "", "Reference to the secret in the secrets provider")
-	lifecycleExternalSecretCreateCmd.Flags().StringVarP(&utils.SecretManagerAccessId, "secret-manager-access-id", "", "", "Secret manager access ID")
+	lifecycleExternalSecretCreateCmd.Flags().StringVarP(&utils.SecretManagerAccessName, "secret-manager-access-name", "", "", "Secret manager access name")
 	lifecycleExternalSecretCreateCmd.Flags().StringVarP(&utils.JobScope, "scope", "", "JOB", "Scope of this external secret <PROJECT|ENVIRONMENT|JOB>")
 	lifecycleExternalSecretCreateCmd.Flags().StringVarP(&utils.MountPath, "mount-path", "", "", "Path where the secret will be mounted as a file")
 
 	_ = lifecycleExternalSecretCreateCmd.MarkFlagRequired("key")
 	_ = lifecycleExternalSecretCreateCmd.MarkFlagRequired("reference")
-	_ = lifecycleExternalSecretCreateCmd.MarkFlagRequired("secret-manager-access-id")
+	_ = lifecycleExternalSecretCreateCmd.MarkFlagRequired("secret-manager-access-name")
 	_ = lifecycleExternalSecretCreateCmd.MarkFlagRequired("lifecycle")
 }

--- a/cmd/lifecycle_external_secret_update.go
+++ b/cmd/lifecycle_external_secret_update.go
@@ -25,7 +25,7 @@ var lifecycleExternalSecretUpdateCmd = &cobra.Command{
 		}
 
 		client := utils.GetQoveryClient(tokenType, token)
-		_, _, envId, err := getOrganizationProjectEnvironmentContextResourcesIds(client)
+		organizationId, _, envId, err := getOrganizationProjectEnvironmentContextResourcesIds(client)
 
 		if err != nil {
 			utils.PrintlnError(err)
@@ -50,7 +50,14 @@ var lifecycleExternalSecretUpdateCmd = &cobra.Command{
 			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
-		err = utils.UpdateServiceExternalSecret(client, utils.Key, utils.Reference, utils.SecretManagerAccessId, lifecycle.LifecycleJobResponse.Id, utils.JobType)
+		secretManagerAccessId, err := getSecretManagerAccessIdByName(client, organizationId, envId, utils.SecretManagerAccessName)
+		if err != nil {
+			utils.PrintlnError(err)
+			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
+		}
+
+		err = utils.UpdateServiceExternalSecret(client, utils.Key, utils.Reference, secretManagerAccessId, lifecycle.LifecycleJobResponse.Id, utils.JobType)
 
 		if err != nil {
 			utils.PrintlnError(err)
@@ -70,7 +77,7 @@ func init() {
 	lifecycleExternalSecretUpdateCmd.Flags().StringVarP(&lifecycleName, "lifecycle", "n", "", "Lifecycle Name")
 	lifecycleExternalSecretUpdateCmd.Flags().StringVarP(&utils.Key, "key", "k", "", "External secret key")
 	lifecycleExternalSecretUpdateCmd.Flags().StringVarP(&utils.Reference, "reference", "r", "", "New reference to the secret in the secrets provider")
-	lifecycleExternalSecretUpdateCmd.Flags().StringVarP(&utils.SecretManagerAccessId, "secret-manager-access-id", "", "", "New secret manager access ID")
+	lifecycleExternalSecretUpdateCmd.Flags().StringVarP(&utils.SecretManagerAccessName, "secret-manager-access-name", "", "", "New secret manager access name")
 
 	_ = lifecycleExternalSecretUpdateCmd.MarkFlagRequired("key")
 	_ = lifecycleExternalSecretUpdateCmd.MarkFlagRequired("lifecycle")

--- a/cmd/terraform_external_secret_create.go
+++ b/cmd/terraform_external_secret_create.go
@@ -25,7 +25,7 @@ var terraformExternalSecretCreateCmd = &cobra.Command{
 		}
 
 		client := utils.GetQoveryClient(tokenType, token)
-		_, projectId, envId, err := getOrganizationProjectEnvironmentContextResourcesIds(client)
+		organizationId, projectId, envId, err := getOrganizationProjectEnvironmentContextResourcesIds(client)
 
 		if err != nil {
 			utils.PrintlnError(err)
@@ -50,7 +50,14 @@ var terraformExternalSecretCreateCmd = &cobra.Command{
 			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
-		err = utils.CreateServiceExternalSecret(client, projectId, envId, terraform.Id, utils.TerraformScope, utils.Key, utils.Reference, utils.SecretManagerAccessId, utils.MountPath)
+		secretManagerAccessId, err := getSecretManagerAccessIdByName(client, organizationId, envId, utils.SecretManagerAccessName)
+		if err != nil {
+			utils.PrintlnError(err)
+			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
+		}
+
+		err = utils.CreateServiceExternalSecret(client, projectId, envId, terraform.Id, utils.TerraformScope, utils.Key, utils.Reference, secretManagerAccessId, utils.MountPath)
 
 		if err != nil {
 			utils.PrintlnError(err)
@@ -70,12 +77,12 @@ func init() {
 	terraformExternalSecretCreateCmd.Flags().StringVarP(&terraformName, "terraform", "n", "", "Terraform Name")
 	terraformExternalSecretCreateCmd.Flags().StringVarP(&utils.Key, "key", "k", "", "External secret key")
 	terraformExternalSecretCreateCmd.Flags().StringVarP(&utils.Reference, "reference", "r", "", "Reference to the secret in the secrets provider")
-	terraformExternalSecretCreateCmd.Flags().StringVarP(&utils.SecretManagerAccessId, "secret-manager-access-id", "", "", "Secret manager access ID")
+	terraformExternalSecretCreateCmd.Flags().StringVarP(&utils.SecretManagerAccessName, "secret-manager-access-name", "", "", "Secret manager access name")
 	terraformExternalSecretCreateCmd.Flags().StringVarP(&utils.TerraformScope, "scope", "", "TERRAFORM", "Scope of this external secret <PROJECT|ENVIRONMENT|TERRAFORM>")
 	terraformExternalSecretCreateCmd.Flags().StringVarP(&utils.MountPath, "mount-path", "", "", "Path where the secret will be mounted as a file")
 
 	_ = terraformExternalSecretCreateCmd.MarkFlagRequired("key")
 	_ = terraformExternalSecretCreateCmd.MarkFlagRequired("reference")
-	_ = terraformExternalSecretCreateCmd.MarkFlagRequired("secret-manager-access-id")
+	_ = terraformExternalSecretCreateCmd.MarkFlagRequired("secret-manager-access-name")
 	_ = terraformExternalSecretCreateCmd.MarkFlagRequired("terraform")
 }

--- a/cmd/terraform_external_secret_update.go
+++ b/cmd/terraform_external_secret_update.go
@@ -25,7 +25,7 @@ var terraformExternalSecretUpdateCmd = &cobra.Command{
 		}
 
 		client := utils.GetQoveryClient(tokenType, token)
-		_, _, envId, err := getOrganizationProjectEnvironmentContextResourcesIds(client)
+		organizationId, _, envId, err := getOrganizationProjectEnvironmentContextResourcesIds(client)
 
 		if err != nil {
 			utils.PrintlnError(err)
@@ -50,7 +50,14 @@ var terraformExternalSecretUpdateCmd = &cobra.Command{
 			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
-		err = utils.UpdateServiceExternalSecret(client, utils.Key, utils.Reference, utils.SecretManagerAccessId, terraform.Id, utils.TerraformType)
+		secretManagerAccessId, err := getSecretManagerAccessIdByName(client, organizationId, envId, utils.SecretManagerAccessName)
+		if err != nil {
+			utils.PrintlnError(err)
+			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
+		}
+
+		err = utils.UpdateServiceExternalSecret(client, utils.Key, utils.Reference, secretManagerAccessId, terraform.Id, utils.TerraformType)
 
 		if err != nil {
 			utils.PrintlnError(err)
@@ -70,7 +77,7 @@ func init() {
 	terraformExternalSecretUpdateCmd.Flags().StringVarP(&terraformName, "terraform", "n", "", "Terraform Name")
 	terraformExternalSecretUpdateCmd.Flags().StringVarP(&utils.Key, "key", "k", "", "External secret key")
 	terraformExternalSecretUpdateCmd.Flags().StringVarP(&utils.Reference, "reference", "r", "", "New reference to the secret in the secrets provider")
-	terraformExternalSecretUpdateCmd.Flags().StringVarP(&utils.SecretManagerAccessId, "secret-manager-access-id", "", "", "New secret manager access ID")
+	terraformExternalSecretUpdateCmd.Flags().StringVarP(&utils.SecretManagerAccessName, "secret-manager-access-name", "", "", "New secret manager access name")
 
 	_ = terraformExternalSecretUpdateCmd.MarkFlagRequired("key")
 	_ = terraformExternalSecretUpdateCmd.MarkFlagRequired("terraform")

--- a/utils/env_var.go
+++ b/utils/env_var.go
@@ -25,7 +25,7 @@ var EnvironmentScope string
 var Alias string
 var Key string
 var Value string
-var SecretManagerAccessId string
+var SecretManagerAccessName string
 var Reference string
 var MountPath string
 var TerraformScope string


### PR DESCRIPTION
Relying on secret manager access name is better for user experience