### PR TITLE
chore: update PostHog endpoint to e.qovery.com

### DIFF
--- a/utils/posthog.go
+++ b/utils/posthog.go
@@ -42,7 +42,7 @@ func CaptureWithEventAndProperties(command *cobra.Command, event string, propert
 	ph, err := posthog.NewWithConfig(
 		"phc_IgdG1K2GveDUte1gJ6hlwNbFHCv9nViWETUyLMU7ciq",
 		posthog.Config{
-			Endpoint: "https://phprox.qovery.com",
+			Endpoint: "https://e.qovery.com",
 		},
 	)
 


### PR DESCRIPTION
## Summary
- Update the PostHog capture endpoint in `utils/posthog.go` from `https://phprox.qovery.com` to `https://e.qovery.com`

## Test plan
- [x] Built the CLI locally and ran `qovery demo up`
- [x] Verified `https://e.qovery.com/capture/` accepts the project API key and returns `{"status":"Ok"}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)