### PR TITLE
fix: sort projects, environments, and services alphabetically in context set

### DIFF
--- a/utils/qovery.go
+++ b/utils/qovery.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -251,6 +252,7 @@ func SelectProject(organizationID Id) (*Project, error) {
 		projectsNames = append(projectsNames, proj.Name)
 		projects[proj.Name] = proj.Id
 	}
+	sort.Strings(projectsNames)
 
 	if len(projectsNames) < 1 {
 		return nil, errors.New("no projects found")
@@ -347,6 +349,7 @@ func SelectEnvironment(projectID Id) (*Environment, error) {
 		environmentsNames = append(environmentsNames, env.Name)
 		environments[env.Name] = env
 	}
+	sort.Strings(environmentsNames)
 
 	if len(environmentsNames) < 1 {
 		return nil, errors.New("no environments found")
@@ -620,6 +623,8 @@ func SelectService(environment Id) (*Service, error) {
 			Type: TerraformType,
 		}
 	}
+	sort.Strings(servicesNames)
+
 	if len(servicesNames) < 1 {
 		return nil, errors.New("no services found")
 	}

--- a/utils/qovery.go
+++ b/utils/qovery.go
@@ -27,6 +27,12 @@ func init() {
 	})
 }
 
+func sortNamesCaseInsensitive(names []string) {
+	sort.Slice(names, func(i, j int) bool {
+		return strings.ToLower(names[i]) < strings.ToLower(names[j])
+	})
+}
+
 type Organization struct {
 	ID   Id
 	Name Name
@@ -156,6 +162,7 @@ func SelectOrganization() (*Organization, error) {
 		organizationNames = append(organizationNames, org.Name)
 		orgs[org.Name] = org.Id
 	}
+	sortNamesCaseInsensitive(organizationNames)
 
 	if len(organizationNames) < 1 {
 		return nil, errors.New("no organizations found")
@@ -252,7 +259,7 @@ func SelectProject(organizationID Id) (*Project, error) {
 		projectsNames = append(projectsNames, proj.Name)
 		projects[proj.Name] = proj.Id
 	}
-	sort.Strings(projectsNames)
+	sortNamesCaseInsensitive(projectsNames)
 
 	if len(projectsNames) < 1 {
 		return nil, errors.New("no projects found")
@@ -349,7 +356,7 @@ func SelectEnvironment(projectID Id) (*Environment, error) {
 		environmentsNames = append(environmentsNames, env.Name)
 		environments[env.Name] = env
 	}
-	sort.Strings(environmentsNames)
+	sortNamesCaseInsensitive(environmentsNames)
 
 	if len(environmentsNames) < 1 {
 		return nil, errors.New("no environments found")
@@ -623,7 +630,7 @@ func SelectService(environment Id) (*Service, error) {
 			Type: TerraformType,
 		}
 	}
-	sort.Strings(servicesNames)
+	sortNamesCaseInsensitive(servicesNames)
 
 	if len(servicesNames) < 1 {
 		return nil, errors.New("no services found")


### PR DESCRIPTION
## Summary
- `qovery context set` listed orga, projects, environments, and services in whatever order the API returned them, making the interactive picker hard to scan for orgs/environments with many entries.
- Sorts each list alphabetically right after collecting the names, before they're shown in the `promptui.Select` picker.


## Test plan
- [x] `go build ./...` succeeds
- [ x] Manually run `qovery context set` against an org with multiple projects/environments/services and confirm the picker lists are alphabetized