### PR TITLE
feat: add qovery auth status command with live token validation

### DIFF
--- a/cmd/auth_status.go
+++ b/cmd/auth_status.go
@@ -1,0 +1,125 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/qovery/qovery-cli/utils"
+)
+
+var authStatusCmd = &cobra.Command{
+	Use:   "status",
+	Short: "Show authentication status without exposing the access token",
+	Long: `Show whether the CLI is currently authenticated, as whom, which organization
+is selected, and when the session expires.
+
+This command never prints the access token or any other secret value, regardless
+of flags. Use it as the safe way to check authentication from scripts, CI, and
+automation, instead of parsing the output of 'qovery auth token':
+
+  qovery auth status >/dev/null 2>&1 && echo authenticated || echo "not authenticated"
+
+Unlike most other commands, this always makes a live call to the Qovery API to
+confirm the token is currently accepted — a token that is present and well-formed
+but has been revoked or expired server-side is reported as not authenticated,
+whether it came from a browser login or from QOVERY_CLI_ACCESS_TOKEN / Q_CLI_ACCESS_TOKEN.
+
+Exit code is 0 when authenticated, 1 otherwise.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		utils.Capture(cmd)
+
+		tokenType, token, err := utils.GetAccessToken()
+		if err != nil {
+			printAuthStatus(authStatusOutput{
+				Authenticated: false,
+				APIURL:        utils.GetAPIBaseURL(),
+			})
+			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
+		}
+
+		// GetAccessToken only verifies validity server-side for browser/device-flow
+		// (context-stored) sessions. A token supplied via QOVERY_CLI_ACCESS_TOKEN or
+		// Q_CLI_ACCESS_TOKEN is returned as-is with no server round trip, so it can look
+		// well-formed while already being revoked or expired. Always re-verify here,
+		// regardless of where the token came from, so "authenticated" means "the server
+		// currently accepts this token" rather than "a token-shaped string exists".
+		client := utils.GetQoveryClient(tokenType, token)
+		if _, _, verifyErr := client.OrganizationMainCallsAPI.ListOrganization(context.Background()).Execute(); verifyErr != nil {
+			printAuthStatus(authStatusOutput{
+				Authenticated: false,
+				APIURL:        utils.GetAPIBaseURL(),
+			})
+			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
+		}
+
+		output := authStatusOutput{
+			Authenticated: true,
+			TokenType:     string(tokenType),
+			APIURL:        utils.GetAPIBaseURL(),
+		}
+
+		// Best-effort: context is only populated for browser/device-flow (Bearer) logins,
+		// not for a raw API token passed via QOVERY_CLI_ACCESS_TOKEN / Q_CLI_ACCESS_TOKEN.
+		if ctx, ctxErr := utils.GetCurrentContext(); ctxErr == nil {
+			if !ctx.AccessTokenExpiration.IsZero() {
+				output.ExpiresAt = ctx.AccessTokenExpiration.UTC().Format("2006-01-02T15:04:05Z")
+			}
+			output.OrganizationId = string(ctx.OrganizationId)
+			output.OrganizationName = string(ctx.OrganizationName)
+			output.User = string(ctx.User)
+		}
+
+		printAuthStatus(output)
+	},
+}
+
+type authStatusOutput struct {
+	Authenticated    bool   `json:"authenticated"`
+	TokenType        string `json:"token_type,omitempty"`
+	ExpiresAt        string `json:"expires_at,omitempty"`
+	OrganizationId   string `json:"organization_id,omitempty"`
+	OrganizationName string `json:"organization_name,omitempty"`
+	User             string `json:"user,omitempty"`
+	APIURL           string `json:"api_url"`
+}
+
+func printAuthStatus(output authStatusOutput) {
+	if jsonFlag {
+		jsonBytes, err := json.MarshalIndent(output, "", "  ")
+		if err != nil {
+			utils.PrintlnError(err)
+			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
+		}
+		utils.Println(string(jsonBytes))
+		return
+	}
+
+	if !output.Authenticated {
+		utils.Println("Not authenticated. Run 'qovery auth' to log in.")
+		return
+	}
+
+	utils.Println("Authenticated:  yes")
+	utils.Println("Token type:     " + output.TokenType)
+	if output.ExpiresAt != "" {
+		utils.Println("Expires at:     " + output.ExpiresAt)
+	}
+	if output.OrganizationName != "" {
+		utils.Println("Organization:   " + output.OrganizationName + " (" + output.OrganizationId + ")")
+	}
+	if output.User != "" {
+		utils.Println("User:           " + output.User)
+	}
+	utils.Println("API URL:        " + output.APIURL)
+}
+
+func init() {
+	authCmd.AddCommand(authStatusCmd)
+	authStatusCmd.Flags().BoolVarP(&jsonFlag, "json", "", false, "JSON output")
+}

--- a/cmd/auth_token.go
+++ b/cmd/auth_token.go
@@ -21,8 +21,12 @@ var authTokenCmd = &cobra.Command{
 This command provides a valid access token that can be used to make direct API calls 
 to the Qovery API. The token is automatically refreshed if it has expired.
 
-For security reasons, the token is not printed by default. You must explicitly 
+For security reasons, the token is not printed by default. You must explicitly
 use --print or --json to output the token value.
+
+If you only need to check whether the CLI is authenticated (e.g. from a script
+or an automated agent), use 'qovery auth status' instead — it never prints the
+token, even with --json.
 
 Examples:
   # Print the raw token value


### PR DESCRIPTION
## Summary
- Adds `qovery auth status` — reports authentication state (authenticated, token type, expiry, organization, user) without ever including the access token, even with `--json`.
- Always performs a live `ListOrganization` call to verify the token server-side, regardless of auth mode. Previously, `GetAccessToken()` only live-verified browser/device-flow (Bearer/context) sessions — a token supplied via `QOVERY_CLI_ACCESS_TOKEN` / `Q_CLI_ACCESS_TOKEN` was returned as-is with no server round trip, so a revoked or expired token could still report as valid.
⚠️  if the token can't list the organization, it will fail (example: OPA not allowing /organization endpoint). maybe we should provide another way to know if a token is valid or not
- Exit code is `0` when authenticated, `1` otherwise, so it works as a black-box check: `qovery auth status >/dev/null 2>&1 && ... || ...`.
- Points to the new command from `auth token`'s help text, for the "just checking if I'm logged in" use case that previously required `--print`/`--json` (i.e. exposing the raw token) to answer.

## Motivation
`auth token` is the only existing way to introspect auth, and every output mode exposes the raw secret — there's no safe primitive for a script, CI job, or automated agent to ask "am I logged in" without also getting the token back. This adds that primitive, and closes a related gap where the API-token env var path was never actually validated against the server.

## Test plan
- [x] `go build ./...` — clean
- [x] `gofmt -l` on changed files — clean
- [x] Manual: `qovery auth status` / `--json` against a real browser-login session — reports `authenticated: true` with type/expiry/org/user, no secret in either output
- [x] Manual: `QOVERY_CLI_ACCESS_TOKEN=<invalid>  qovery auth status` — reports `authenticated: false`, exit 1 (previously would have reported `true` for any non-empty string)
- [ ] Reviewer: confirm the extra `ListOrganization` call per invocation is acceptable latency/rate-limit-wise for this command's use case