### PR TITLE
feat: add qovery api spec command

### DIFF
--- a/cmd/api_spec.go
+++ b/cmd/api_spec.go
@@ -72,11 +72,20 @@ EXAMPLES
 				os.Exit(1)
 				panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 			}
-			utils.PrintlnInfo("OpenAPI spec written to " + apiSpecOutput)
+			// Status message goes to stderr, not stdout, so stdout stays reserved
+			// for the spec itself (the whole point of -o is a clean stdout to script against).
+			fmt.Fprintln(os.Stderr, "OpenAPI spec written to "+apiSpecOutput)
 			return
 		}
 
-		_, _ = os.Stdout.Write(body)
+		if n, err := os.Stdout.Write(body); err != nil || n != len(body) {
+			if err == nil {
+				err = fmt.Errorf("short write: wrote %d of %d bytes", n, len(body))
+			}
+			utils.PrintlnError(err)
+			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
+		}
 	},
 }
 

--- a/cmd/api_spec.go
+++ b/cmd/api_spec.go
@@ -1,0 +1,86 @@
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/qovery/qovery-cli/utils"
+)
+
+// openAPISpecURL points at the canonical source of truth for the Qovery API spec.
+// There is no dedicated docs site serving the raw file (api-doc.qovery.com now
+// redirects to the rendered docs), so the GitHub repo itself is the only stable
+// place to fetch it from.
+const openAPISpecURL = "https://raw.githubusercontent.com/Qovery/qovery-openapi-spec/main/openapi.yaml"
+
+var apiSpecOutput string
+
+var apiSpecCmd = &cobra.Command{
+	Use:   "spec",
+	Short: "Print the Qovery API's OpenAPI specification",
+	Long: `Fetch and print the Qovery API's OpenAPI specification (YAML), sourced from
+https://github.com/Qovery/qovery-openapi-spec.
+
+Use it to discover valid endpoints, methods, and request/response shapes before
+calling 'qovery api <endpoint>' — instead of guessing or relying on a copy that
+may be out of date. This command does not require authentication.
+
+EXAMPLES
+
+  # Print the spec to stdout
+  $ qovery api spec
+
+  # Save it to a file
+  $ qovery api spec -o openapi.yaml
+
+  # Look up one path with a YAML query tool
+  $ qovery api spec | yq '.paths["/organization"]'`,
+	Args: cobra.NoArgs,
+	Run: func(cmd *cobra.Command, args []string) {
+		utils.Capture(cmd)
+
+		client := &http.Client{Timeout: 30 * time.Second}
+		resp, err := client.Get(openAPISpecURL)
+		if err != nil {
+			utils.PrintlnError(fmt.Errorf("could not reach %s: %w", openAPISpecURL, err))
+			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
+		}
+		defer func() { _ = resp.Body.Close() }()
+
+		if resp.StatusCode != http.StatusOK {
+			utils.PrintlnError(fmt.Errorf("failed to fetch OpenAPI spec: server returned %s", resp.Status))
+			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
+		}
+
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			utils.PrintlnError(err)
+			os.Exit(1)
+			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
+		}
+
+		if apiSpecOutput != "" {
+			if err := os.WriteFile(apiSpecOutput, body, 0644); err != nil {
+				utils.PrintlnError(err)
+				os.Exit(1)
+				panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
+			}
+			utils.PrintlnInfo("OpenAPI spec written to " + apiSpecOutput)
+			return
+		}
+
+		_, _ = os.Stdout.Write(body)
+	},
+}
+
+func init() {
+	apiCmd.AddCommand(apiSpecCmd)
+	apiSpecCmd.Flags().StringVarP(&apiSpecOutput, "output", "o", "", "Write the spec to a file instead of stdout")
+}

--- a/cmd/api_spec.go
+++ b/cmd/api_spec.go
@@ -49,28 +49,24 @@ EXAMPLES
 		if err != nil {
 			utils.PrintlnError(fmt.Errorf("could not reach %s: %w", openAPISpecURL, err))
 			os.Exit(1)
-			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 		defer func() { _ = resp.Body.Close() }()
 
 		if resp.StatusCode != http.StatusOK {
 			utils.PrintlnError(fmt.Errorf("failed to fetch OpenAPI spec: server returned %s", resp.Status))
 			os.Exit(1)
-			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)
-			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		if apiSpecOutput != "" {
 			if err := os.WriteFile(apiSpecOutput, body, 0644); err != nil {
 				utils.PrintlnError(err)
 				os.Exit(1)
-				panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 			}
 			// Status message goes to stderr, not stdout, so stdout stays reserved
 			// for the spec itself (the whole point of -o is a clean stdout to script against).
@@ -84,7 +80,6 @@ EXAMPLES
 			}
 			utils.PrintlnError(err)
 			os.Exit(1)
-			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 	},
 }


### PR DESCRIPTION
## Summary
- Adds `qovery api spec`, a subcommand of the existing `qovery api` — fetches and prints the Qovery OpenAPI spec (YAML), from `Qovery/qovery-openapi-spec`.
- No authentication required.
- `-o/--output <file>` writes the spec to a file instead of stdout.
- Added as a subcommand rather than a `--spec` flag on `api` or a new top-level `qovery openapi` command: `api <endpoint>` always expects an endpoint argument and always makes a live authenticated call, so a flag with neither would mix two different mental models. A subcommand keeps `api <endpoint>` completely unchanged and follows the same "parent command with its own default action + read-only subcommands" shape already used by `auth` (login vs. `auth status`/`auth token`) and `context` (show current context vs. `context set`).

## Motivation
There's no built-in way to discover valid endpoints/methods/schemas before calling `qovery api <endpoint>` — today that means guessing, or trusting an external raw GitHub URL that a script/agent has to know about and that may be out of sync with the installed CLI. `api-doc.qovery.com` no longer serves the raw file either (it redirects to the rendered docs site), so the GitHub repo is the only stable source; this wraps that in the CLI directly.

## Test plan
- [x] `go build ./...` — clean
- [x] `gofmt -l` on the changed file — clean
- [x] `qovery api --help` — `spec` listed as a subcommand, existing `api <endpoint>` usage/examples unchanged
- [x] `qovery api spec` — fetches and prints the live spec (31k lines of YAML)
- [x] `qovery api spec -o file.yaml` — writes to file
- [x] `qovery api organization` (pre-existing passthrough) — still resolves and works, confirming `spec` doesn't shadow real endpoint calls
- [ ] Reviewer: confirm pulling from `raw.githubusercontent.com` (rather than e.g. embedding/caching a copy pinned to the CLI's release) is the right tradeoff — this always reflects the live API surface but adds a network dependency and no offline fallback