### PR TITLE
docs: update README with installation instructions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,6 +71,9 @@ jobs:
   # GitHub action usage
   container:
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      packages: write
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -96,13 +99,25 @@ jobs:
         uses: aws-actions/amazon-ecr-login@v2
         with:
           registry-type: public
-      - name: Build, Tag, and push image to Amazon ECR
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build, tag, and push images
         env:
           ECR_REGISTRY: public.ecr.aws/r3m4q3r9
           ECR_REPOSITORY: qovery-cli
+          GHCR_REGISTRY: ghcr.io
+          GHCR_REPOSITORY: qovery/qovery-cli
           IMAGE_TAG: ${{ steps.vars.outputs.tag }}
         run: |
-          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG . --build-arg APP_VERSION=$IMAGE_TAG
+          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG . --build-arg APP_VERSION=$IMAGE_TAG --label org.opencontainers.image.source=https://github.com/Qovery/qovery-cli
           docker tag $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG $ECR_REGISTRY/$ECR_REPOSITORY:latest
+          docker tag $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG $GHCR_REGISTRY/$GHCR_REPOSITORY:$IMAGE_TAG
+          docker tag $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG $GHCR_REGISTRY/$GHCR_REPOSITORY:latest
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:latest
+          docker push $GHCR_REGISTRY/$GHCR_REPOSITORY:$IMAGE_TAG
+          docker push $GHCR_REGISTRY/$GHCR_REPOSITORY:latest

--- a/README.md
+++ b/README.md
@@ -80,16 +80,6 @@ qovery version
 
 You can use `qovery auth` to authenticate with the CLI or use `Q_CLI_ACCESS_TOKEN` (or `QOVERY_CLI_ACCESS_TOKEN`) environment variable to set your API token.
 
-## Versions
-
-You can install the latest version of the CLI:
-
-- On Mac: with brew `brew install qovery-cli`
-- On ArchLinux: with `yay qovery-cli`
-- On Windows: with scoop `scoop install qovery-cli`
-- On Docker: at the address `public.ecr.aws/r3m4q3r9/qovery-cli`
-- From binary: <https://github.com/Qovery/qovery-cli/releases>
-
 # Update deps
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -1,12 +1,80 @@
 <p align="center">
-  <img alt="Qovery Logo" src="https://raw.githubusercontent.com/Qovery/public-resources/master/qovery%20logo%20horizontal%20without%20margin.png" />
+  <img alt="Qovery Logo" src="https://www.qovery.com/logos/qovery-logo-black.svg" />
 </p>
 
 [Qovery](https://www.qovery.com/) helps tech companies to accelerate and scale application development cycle with zero infrastructure management investment.
 
 This repository is the code source of the Qovery CLI.
 
-See our complete documentation [here](https://docs.qovery.com) to get started with Qovery.
+See the [Qovery documentation](https://docs.qovery.com) to get started with Qovery.
+
+See the [Qovery CLI documentation](https://www.qovery.com/docs/cli/overview) to get started with the CLI and explore its commands.
+
+## Installation
+
+Choose the installation method for your platform.
+
+### Linux
+
+Install the latest version on any Linux distribution:
+
+```sh
+curl -s https://get.qovery.com | bash
+```
+
+For security-sensitive environments, install from a [pinned GitHub release](https://github.com/Qovery/qovery-cli/releases) and verify the downloaded archive against that release's `checksums.txt`. The convenience script does not perform an integrity check.
+
+### macOS
+
+Install with Homebrew:
+
+```sh
+brew tap Qovery/qovery-cli
+brew install qovery-cli
+```
+
+Alternatively, use the installer script:
+
+```sh
+curl -s https://get.qovery.com | bash
+```
+
+For a pinned, checksum-verified installation, use a [GitHub release](https://github.com/Qovery/qovery-cli/releases).
+
+### Windows
+
+Install with [Scoop](https://scoop.sh/):
+
+```powershell
+scoop bucket add qovery https://github.com/Qovery/scoop-qovery-cli
+scoop install qovery-cli
+```
+
+You can also download a release archive from [GitHub Releases](https://github.com/Qovery/qovery-cli/releases) and add the extracted `qovery` executable to your `PATH`.
+
+### Arch Linux
+
+The CLI is available through the AUR:
+
+```sh
+yay qovery-cli
+```
+
+### Docker
+
+Run the CLI without installing it locally:
+
+```sh
+docker run ghcr.io/qovery/qovery-cli:latest help
+```
+
+Replace `latest` with a specific version when you need reproducible builds.
+
+### Verify the installation
+
+```sh
+qovery version
+```
 
 ## Authentication
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds platform-specific install instructions to the README and publishes the CLI image to GHCR, so users can install on any OS and run the CLI via `Docker` without a local install. Previously only ECR images were published; now images are pushed to both ECR and GHCR, and the README points to GHCR.

- Adds a curl installer for Linux/macOS and documents a pinned release + checksum workflow for verification.
- Documents installs via `Homebrew`, `Scoop`, and `AUR`.
- Adds `Docker` usage with `ghcr.io/qovery/qovery-cli` and recommends pinning a version.
- Adds a post-install verification step with the CLI version command.
- Updates doc links and the logo URL.
- Updates the release workflow to log in to GHCR, tag and push images to `ghcr.io/qovery/qovery-cli` alongside ECR, add an OCI source label, and grant `packages: write` permission.

<sup>Written for commit edda44ab82f122e119d3cd09d67e2599a4e2c4d7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Qovery/qovery-cli/pull/694?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

