### PR TITLE
fix: remove unnecessary panic("unreachable") after os.Exit(1) in auth_status.go

### DIFF
--- a/cmd/auth_status.go
+++ b/cmd/auth_status.go
@@ -38,7 +38,6 @@ Exit code is 0 when authenticated, 1 otherwise.`,
 				APIURL:        utils.GetAPIBaseURL(),
 			})
 			os.Exit(1)
-			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		// GetAccessToken only verifies validity server-side for browser/device-flow
@@ -54,7 +53,6 @@ Exit code is 0 when authenticated, 1 otherwise.`,
 				APIURL:        utils.GetAPIBaseURL(),
 			})
 			os.Exit(1)
-			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
 		output := authStatusOutput{
@@ -94,7 +92,6 @@ func printAuthStatus(output authStatusOutput) {
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)
-			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 		utils.Println(string(jsonBytes))
 		return


### PR DESCRIPTION
## Summary
Follow-up to review feedback on #691 (`qovery api spec`), which had the same issue: `panic("unreachable") // staticcheck false positive` was copied by analogy into `auth_status.go` (merged in #690) without checking it actually applied there.

The pattern only matters when code *after* `os.Exit(1)` dereferences something staticcheck's flow analysis can't prove is safe (staticcheck doesn't know `os.Exit` never returns). None of the three `os.Exit(1)` calls in `auth_status.go` are followed by such a dereference, so there's nothing for staticcheck to misjudge.

## Test plan
- [x] Removed all three `panic("unreachable")` lines
- [x] `staticcheck ./cmd/...` — no findings for this file
- [x] `go vet ./cmd/...` — clean
- [x] `go build ./...` — clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the redundant panic("unreachable") calls after os.Exit(1) in `auth_status.go`; they were meant to guard against SA5011 but no dereference follows those exits, so they weren’t needed. Runtime behavior is unchanged; this just cleans up noise and avoids a misleading staticcheck comment.

<sup>Written for commit 20172402c22839a6b720eb631229a09a7d479056. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Qovery/qovery-cli/pull/695?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

