### PR TITLE
fix(byok): use packaged Envoy Gateway CRD chart path

### DIFF
--- a/pkg/cluster/selfmanaged/install_self_managed_cluster_service.go
+++ b/pkg/cluster/selfmanaged/install_self_managed_cluster_service.go
@@ -266,7 +266,7 @@ Helm values location: %s
 # Pre-apply Gateway API and Envoy CRDs before the main Helm release.
 # The CRD bundle is too large to fit reliably in Helm's release Secret storage.
 helm pull qovery/qovery --untar --untardir /tmp/qovery-helm-chart
-helm template qovery-gateway-crds /tmp/qovery-helm-chart/qovery/charts/envoy-gateway-crd \
+helm template qovery-gateway-crds /tmp/qovery-helm-chart/qovery/charts/gateway-crds-helm \
 	 --set crds.gatewayAPI.enabled=true \
 	 --set crds.gatewayAPI.channel=standard \
 	 --set crds.envoyGateway.enabled=true | kubectl apply --server-side -f -

--- a/pkg/cluster/selfmanaged/install_self_managed_cluster_service_test.go
+++ b/pkg/cluster/selfmanaged/install_self_managed_cluster_service_test.go
@@ -788,7 +788,7 @@ func TestOutputCommandsToInstallQoveryOnCluster(t *testing.T) {
 	})
 
 	assert.Contains(t, output, "helm pull qovery/qovery --untar --untardir /tmp/qovery-helm-chart")
-	assert.Contains(t, output, "helm template qovery-gateway-crds /tmp/qovery-helm-chart/qovery/charts/envoy-gateway-crd")
+	assert.Contains(t, output, "helm template qovery-gateway-crds /tmp/qovery-helm-chart/qovery/charts/gateway-crds-helm")
 	assert.Contains(t, output, "kubectl apply --server-side -f -")
 	assert.Contains(t, output, "kubectl wait --for=condition=Established --timeout=180s crd/gateways.gateway.networking.k8s.io")
 	assert.Contains(t, output, "kubectl wait --for=condition=Established --timeout=180s crd/envoyproxies.gateway.envoyproxy.io")


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixed the self-managed install script to point to the correct packaged Gateway CRD chart path. It now runs `helm template` on `gateway-crds-helm` instead of the nonexistent `envoy-gateway-crd`, so the Gateway API and Envoy CRDs are applied correctly.

<sup>Written for commit e40b000c390f40841b73cef265886a50d633d43f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Qovery/qovery-cli/pull/699?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

