### PR TITLE
fix(demo): support empty engine image overrides on macOS Bash

### DIFF
--- a/cmd/demo_scripts/create_qovery_demo.sh
+++ b/cmd/demo_scripts/create_qovery_demo.sh
@@ -154,7 +154,7 @@ install_or_upgrade_helm_charts() {
       --set services.qovery.qovery-cluster-agent.enabled=false \
       --set services.qovery.qovery-engine.enabled=false \
       --set services.qovery.qovery-operator.enabled=false \
-      "${engine_image_overrides[@]}" qovery "$chart_source"
+      "${engine_image_overrides[@]+"${engine_image_overrides[@]}"}" qovery "$chart_source"
   fi
 
   for i in $(seq 1 3); do
@@ -162,7 +162,7 @@ install_or_upgrade_helm_charts() {
     helm upgrade --install --create-namespace ${HELM_DEBUG} --timeout=15m -n qovery "${helm_values_args[@]}" --wait --atomic \
       --set services.ingress.envoy-gateway-crd.enabled=false \
       --set services.qovery.qovery-operator.enabled=false \
-      "${engine_image_overrides[@]}" qovery "$chart_source" && break
+      "${engine_image_overrides[@]+"${engine_image_overrides[@]}"}" qovery "$chart_source" && break
     set +x
     echo "Install failed. Retrying in 10 seconds. To let the cluster initialize"
     sleep 10

--- a/cmd/demo_up_local_overrides_test.go
+++ b/cmd/demo_up_local_overrides_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -30,5 +31,13 @@ func TestDemoEngineImageOverride(t *testing.T) {
 	}
 	if repository != "docker.io/library/qovery-demo-engine" || tag != "local" {
 		t.Fatalf("expected docker.io/library/qovery-demo-engine:local, got %s:%s", repository, tag)
+	}
+}
+
+func TestDemoScriptUsesNounsetSafeEmptyEngineImageOverrides(t *testing.T) {
+	const nounsetSafeOverrides = `"${engine_image_overrides[@]+"${engine_image_overrides[@]}"}"`
+
+	if count := strings.Count(string(demoScriptsCreate), nounsetSafeOverrides); count != 2 {
+		t.Fatalf("expected both Helm invocations to use a Bash 3.2 nounset-safe engine image override expansion, found %d", count)
 	}
 }


### PR DESCRIPTION
Avoid expanding an empty engine_image_overrides array under set -u, which causes qovery demo up to files
on macOS’s Bash 3.2 with an “unbound variable” error. Add a regression test for the nounset-safe expansion.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `qovery demo up` failing on macOS's Bash 3.2 with an "unbound variable" error when no engine image overrides are set.

**Bug Fixes**
- Expands the empty `engine_image_overrides` array using a Bash 3.2-safe form so `set -u` no longer aborts the script.
- Adds a regression test confirming both Helm invocations use the safe expansion.

<sup>Written for commit 8f4828136504d56217c95b0e6fce1a58f04a2df8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Qovery/qovery-cli/pull/700?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

