### PR TITLE
Allow creating the first organization via qovery api organization

### DIFF
--- a/cmd/admin_cluster_deploy.go
+++ b/cmd/admin_cluster_deploy.go
@@ -101,7 +101,7 @@ func init() {
 func deployClusters() {
 	utils.GetAdminUrl()
 
-	tokenType, token, err := utils.GetAccessToken()
+	tokenType, token, err := utils.GetAccessToken(false)
 	if err != nil {
 		utils.PrintlnError(err)
 		os.Exit(1)

--- a/cmd/admin_cluster_status.go
+++ b/cmd/admin_cluster_status.go
@@ -62,7 +62,7 @@ func readClusterStatus(req ClusterStatusRequest) (*ClusterStatusDto, error) {
 	pattern := regexp.MustCompile("%5B([0-9]+)%5D=")
 	wsURL.RawQuery = pattern.ReplaceAllString(command.Encode(), "[${1}]=")
 
-	tokenType, token, err := utils.GetAccessToken()
+	tokenType, token, err := utils.GetAccessToken(false)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/admin_cluster_update_kubeconfig.go
+++ b/cmd/admin_cluster_update_kubeconfig.go
@@ -28,7 +28,7 @@ func init() {
 }
 
 func updateClusterKubeconfig() {
-	tokenType, token, err := utils.GetAccessToken()
+	tokenType, token, err := utils.GetAccessToken(false)
 	if err != nil {
 		utils.PrintlnError(err)
 		os.Exit(1)

--- a/cmd/admin_demo_get_logs.go
+++ b/cmd/admin_demo_get_logs.go
@@ -30,7 +30,7 @@ var (
 				os.Exit(0)
 			}
 
-			tokenType, token, err := utils.GetAccessToken()
+			tokenType, token, err := utils.GetAccessToken(false)
 			if err != nil {
 				utils.PrintlnError(err)
 				os.Exit(1)

--- a/cmd/admin_demo_list_logs.go
+++ b/cmd/admin_demo_list_logs.go
@@ -25,7 +25,7 @@ var (
 		Run: func(cmd *cobra.Command, args []string) {
 			utils.Capture(cmd)
 
-			tokenType, token, err := utils.GetAccessToken()
+			tokenType, token, err := utils.GetAccessToken(false)
 			if err != nil {
 				utils.PrintlnError(err)
 				os.Exit(1)

--- a/cmd/admin_enable_user_connect.go
+++ b/cmd/admin_enable_user_connect.go
@@ -99,7 +99,7 @@ func enableUserSignup() {
 	}
 
 	// Get access token
-	tokenType, token, err := utils.GetAccessToken()
+	tokenType, token, err := utils.GetAccessToken(false)
 	if err != nil {
 		utils.PrintlnError(err)
 		os.Exit(1)

--- a/cmd/admin_encrypt_secret.go
+++ b/cmd/admin_encrypt_secret.go
@@ -51,7 +51,7 @@ func encryptSecret() {
 }
 
 func callEncryptSecret(organizationId string, secret string) (string, error) {
-	tokenType, token, err := utils.GetAccessToken()
+	tokenType, token, err := utils.GetAccessToken(false)
 	if err != nil {
 		return "", fmt.Errorf("failed to get access token: %w", err)
 	}

--- a/cmd/admin_enterprise_connection_create.go
+++ b/cmd/admin_enterprise_connection_create.go
@@ -35,7 +35,7 @@ func init() {
 
 func createEnterpriseConnection() {
 	// Retrieve access token for authorization
-	tokenType, token, err := utils.GetAccessToken()
+	tokenType, token, err := utils.GetAccessToken(false)
 	checkError(err)
 
 	// Prepare payload with required fields

--- a/cmd/admin_enterprise_connection_delete.go
+++ b/cmd/admin_enterprise_connection_delete.go
@@ -33,7 +33,7 @@ func init() {
 
 func deleteEnterpriseConnection() {
 	// Retrieve access token for authorization
-	tokenType, token, err := utils.GetAccessToken()
+	tokenType, token, err := utils.GetAccessToken(false)
 	checkError(err)
 
 	// Build URL

--- a/cmd/admin_enterprise_connection_list.go
+++ b/cmd/admin_enterprise_connection_list.go
@@ -31,7 +31,7 @@ func init() {
 
 func listEnterpriseConnections() {
 	// Retrieve access token for authorization
-	tokenType, token, err := utils.GetAccessToken()
+	tokenType, token, err := utils.GetAccessToken(false)
 	checkError(err)
 
 	// Build URL

--- a/cmd/admin_jw_qovery_usage_create.go
+++ b/cmd/admin_jw_qovery_usage_create.go
@@ -35,7 +35,7 @@ func init() {
 }
 
 func createJwtForQoveryUsage() {
-	tokenType, token, err := utils.GetAccessToken()
+	tokenType, token, err := utils.GetAccessToken(false)
 	if err != nil {
 		utils.PrintlnError(err)
 		os.Exit(0)

--- a/cmd/admin_jw_qovery_usage_delete.go
+++ b/cmd/admin_jw_qovery_usage_delete.go
@@ -28,7 +28,7 @@ func init() {
 }
 
 func deleteJwtForQoveryUsage() {
-	tokenType, token, err := utils.GetAccessToken()
+	tokenType, token, err := utils.GetAccessToken(false)
 	if err != nil {
 		utils.PrintlnError(err)
 		os.Exit(0)

--- a/cmd/admin_jw_qovery_usage_list.go
+++ b/cmd/admin_jw_qovery_usage_list.go
@@ -32,7 +32,7 @@ func init() {
 }
 
 func listJwtsForQoveryUsage() {
-	tokenType, token, err := utils.GetAccessToken()
+	tokenType, token, err := utils.GetAccessToken(false)
 	if err != nil {
 		utils.PrintlnError(err)
 		os.Exit(0)

--- a/cmd/admin_jwt_create.go
+++ b/cmd/admin_jwt_create.go
@@ -33,7 +33,7 @@ func init() {
 }
 
 func createJwt() {
-	tokenType, token, err := utils.GetAccessToken()
+	tokenType, token, err := utils.GetAccessToken(false)
 	if err != nil {
 		utils.PrintlnError(err)
 		os.Exit(0)

--- a/cmd/admin_jwt_delete.go
+++ b/cmd/admin_jwt_delete.go
@@ -28,7 +28,7 @@ func init() {
 }
 
 func deleteJwt() {
-	tokenType, token, err := utils.GetAccessToken()
+	tokenType, token, err := utils.GetAccessToken(false)
 	if err != nil {
 		utils.PrintlnError(err)
 		os.Exit(0)

--- a/cmd/admin_jwt_list.go
+++ b/cmd/admin_jwt_list.go
@@ -32,7 +32,7 @@ func init() {
 }
 
 func listJwts() {
-	tokenType, token, err := utils.GetAccessToken()
+	tokenType, token, err := utils.GetAccessToken(false)
 	if err != nil {
 		utils.PrintlnError(err)
 		os.Exit(0)

--- a/cmd/admin_organization_deployment_restriction.go
+++ b/cmd/admin_organization_deployment_restriction.go
@@ -104,7 +104,7 @@ func manageOrganizationDeploymentRestriction() {
 	}
 
 	// Get access token
-	tokenType, token, err := utils.GetAccessToken()
+	tokenType, token, err := utils.GetAccessToken(false)
 	if err != nil {
 		utils.PrintlnError(err)
 		os.Exit(1)

--- a/cmd/admin_organization_transfer_ownership.go
+++ b/cmd/admin_organization_transfer_ownership.go
@@ -62,7 +62,7 @@ func transferOrganizationOwnership() {
 	}
 
 	// Get access token
-	tokenType, token, err := utils.GetAccessToken()
+	tokenType, token, err := utils.GetAccessToken(false)
 	if err != nil {
 		utils.PrintlnError(err)
 		os.Exit(1)

--- a/cmd/admin_organization_update_billing_external_id.go
+++ b/cmd/admin_organization_update_billing_external_id.go
@@ -48,7 +48,7 @@ func updateOrganizationBillingExternalId() {
 		os.Exit(1)
 	}
 
-	tokenType, token, err := utils.GetAccessToken()
+	tokenType, token, err := utils.GetAccessToken(false)
 	if err != nil {
 		utils.PrintlnError(err)
 		os.Exit(1)

--- a/cmd/api.go
+++ b/cmd/api.go
@@ -280,7 +280,7 @@ func runAPI(cmd *cobra.Command, args []string) {
 	// --method POST ...`, documented above as a first-class example) is the one
 	// legitimate case where the caller is expected to have zero organizations yet,
 	// so it skips the usual "you don't have any organization" guard.
-	isOrgCreation := strings.Trim(endpoint, "/") == "organization" && method == "POST"
+	isOrgCreation := path == "organization" && method == "POST"
 	var tokenType utils.AccessTokenType
 	var token utils.AccessToken
 	if isOrgCreation {

--- a/cmd/api.go
+++ b/cmd/api.go
@@ -281,13 +281,7 @@ func runAPI(cmd *cobra.Command, args []string) {
 	// legitimate case where the caller is expected to have zero organizations yet,
 	// so it skips the usual "you don't have any organization" guard.
 	isOrgCreation := path == "organization" && method == "POST"
-	var tokenType utils.AccessTokenType
-	var token utils.AccessToken
-	if isOrgCreation {
-		tokenType, token, err = utils.GetAccessTokenAllowNoOrg()
-	} else {
-		tokenType, token, err = utils.GetAccessToken()
-	}
+	tokenType, token, err := utils.GetAccessToken(isOrgCreation)
 	if err != nil {
 		utils.PrintlnError(err)
 		os.Exit(1)

--- a/cmd/api.go
+++ b/cmd/api.go
@@ -276,8 +276,18 @@ func runAPI(cmd *cobra.Command, args []string) {
 		os.Exit(1)
 	}
 
-	// Get auth token
-	tokenType, token, err := utils.GetAccessToken()
+	// Get auth token. Creating the very first organization (`qovery api organization
+	// --method POST ...`, documented above as a first-class example) is the one
+	// legitimate case where the caller is expected to have zero organizations yet,
+	// so it skips the usual "you don't have any organization" guard.
+	isOrgCreation := strings.Trim(endpoint, "/") == "organization" && method == "POST"
+	var tokenType utils.AccessTokenType
+	var token utils.AccessToken
+	if isOrgCreation {
+		tokenType, token, err = utils.GetAccessTokenAllowNoOrg()
+	} else {
+		tokenType, token, err = utils.GetAccessToken()
+	}
 	if err != nil {
 		utils.PrintlnError(err)
 		os.Exit(1)

--- a/cmd/application_cancel.go
+++ b/cmd/application_cancel.go
@@ -16,7 +16,7 @@ var applicationCancelCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Capture(cmd)
 
-		tokenType, token, err := utils.GetAccessToken()
+		tokenType, token, err := utils.GetAccessToken(false)
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)

--- a/cmd/application_clone.go
+++ b/cmd/application_clone.go
@@ -20,7 +20,7 @@ var applicationCloneCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Capture(cmd)
 
-		tokenType, token, err := utils.GetAccessToken()
+		tokenType, token, err := utils.GetAccessToken(false)
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)

--- a/cmd/application_domain_create.go
+++ b/cmd/application_domain_create.go
@@ -22,7 +22,7 @@ var applicationDomainCreateCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Capture(cmd)
 
-		tokenType, token, err := utils.GetAccessToken()
+		tokenType, token, err := utils.GetAccessToken(false)
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)

--- a/cmd/application_domain_delete.go
+++ b/cmd/application_domain_delete.go
@@ -17,7 +17,7 @@ var applicationDomainDeleteCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Capture(cmd)
 
-		tokenType, token, err := utils.GetAccessToken()
+		tokenType, token, err := utils.GetAccessToken(false)
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)

--- a/cmd/application_domain_edit.go
+++ b/cmd/application_domain_edit.go
@@ -19,7 +19,7 @@ var applicationDomainEditCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Capture(cmd)
 
-		tokenType, token, err := utils.GetAccessToken()
+		tokenType, token, err := utils.GetAccessToken(false)
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)

--- a/cmd/application_domain_list.go
+++ b/cmd/application_domain_list.go
@@ -20,7 +20,7 @@ var applicationDomainListCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Capture(cmd)
 
-		tokenType, token, err := utils.GetAccessToken()
+		tokenType, token, err := utils.GetAccessToken(false)
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)

--- a/cmd/application_env_alias_create.go
+++ b/cmd/application_env_alias_create.go
@@ -17,7 +17,7 @@ var applicationEnvAliasCreateCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Capture(cmd)
 
-		tokenType, token, err := utils.GetAccessToken()
+		tokenType, token, err := utils.GetAccessToken(false)
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)

--- a/cmd/application_env_create.go
+++ b/cmd/application_env_create.go
@@ -17,7 +17,7 @@ var applicationEnvCreateCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Capture(cmd)
 
-		tokenType, token, err := utils.GetAccessToken()
+		tokenType, token, err := utils.GetAccessToken(false)
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)

--- a/cmd/application_env_delete.go
+++ b/cmd/application_env_delete.go
@@ -17,7 +17,7 @@ var applicationEnvDeleteCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Capture(cmd)
 
-		tokenType, token, err := utils.GetAccessToken()
+		tokenType, token, err := utils.GetAccessToken(false)
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)

--- a/cmd/application_env_list.go
+++ b/cmd/application_env_list.go
@@ -15,7 +15,7 @@ var applicationEnvListCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Capture(cmd)
 
-		tokenType, token, err := utils.GetAccessToken()
+		tokenType, token, err := utils.GetAccessToken(false)
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)

--- a/cmd/application_env_override_create.go
+++ b/cmd/application_env_override_create.go
@@ -17,7 +17,7 @@ var applicationEnvOverrideCreateCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Capture(cmd)
 
-		tokenType, token, err := utils.GetAccessToken()
+		tokenType, token, err := utils.GetAccessToken(false)
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)

--- a/cmd/application_env_update.go
+++ b/cmd/application_env_update.go
@@ -17,7 +17,7 @@ var applicationEnvUpdateCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Capture(cmd)
 
-		tokenType, token, err := utils.GetAccessToken()
+		tokenType, token, err := utils.GetAccessToken(false)
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)

--- a/cmd/application_external_secret_create.go
+++ b/cmd/application_external_secret_create.go
@@ -17,7 +17,7 @@ var applicationExternalSecretCreateCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Capture(cmd)
 
-		tokenType, token, err := utils.GetAccessToken()
+		tokenType, token, err := utils.GetAccessToken(false)
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)

--- a/cmd/application_external_secret_delete.go
+++ b/cmd/application_external_secret_delete.go
@@ -17,7 +17,7 @@ var applicationExternalSecretDeleteCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Capture(cmd)
 
-		tokenType, token, err := utils.GetAccessToken()
+		tokenType, token, err := utils.GetAccessToken(false)
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)

--- a/cmd/application_external_secret_update.go
+++ b/cmd/application_external_secret_update.go
@@ -17,7 +17,7 @@ var applicationExternalSecretUpdateCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Capture(cmd)
 
-		tokenType, token, err := utils.GetAccessToken()
+		tokenType, token, err := utils.GetAccessToken(false)
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)

--- a/cmd/application_list.go
+++ b/cmd/application_list.go
@@ -16,7 +16,7 @@ var applicationListCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Capture(cmd)
 
-		tokenType, token, err := utils.GetAccessToken()
+		tokenType, token, err := utils.GetAccessToken(false)
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)

--- a/cmd/application_update.go
+++ b/cmd/application_update.go
@@ -18,7 +18,7 @@ var applicationUpdateCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Capture(cmd)
 
-		tokenType, token, err := utils.GetAccessToken()
+		tokenType, token, err := utils.GetAccessToken(false)
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)

--- a/cmd/audit_log_download.go
+++ b/cmd/audit_log_download.go
@@ -60,7 +60,7 @@ func downloadAuditLogs() {
 	utils.Println(fmt.Sprintf("Your organization plan provides  %.0f days of audit log history", org.OrganizationPlan.GetAuditLogsRetentionInDays()))
 
 	// Get access token
-	tokenType, token, err := utils.GetAccessToken()
+	tokenType, token, err := utils.GetAccessToken(false)
 	checkError(err)
 
 	// Create audit log service

--- a/cmd/auth_status.go
+++ b/cmd/auth_status.go
@@ -31,7 +31,7 @@ Exit code is 0 when authenticated, 1 otherwise.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Capture(cmd)
 
-		tokenType, token, err := utils.GetAccessToken(false)
+		tokenType, token, err := utils.GetAccessToken(true)
 		if err != nil {
 			printAuthStatus(authStatusOutput{
 				Authenticated: false,

--- a/cmd/auth_status.go
+++ b/cmd/auth_status.go
@@ -31,7 +31,7 @@ Exit code is 0 when authenticated, 1 otherwise.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Capture(cmd)
 
-		tokenType, token, err := utils.GetAccessToken()
+		tokenType, token, err := utils.GetAccessToken(false)
 		if err != nil {
 			printAuthStatus(authStatusOutput{
 				Authenticated: false,

--- a/cmd/auth_token.go
+++ b/cmd/auth_token.go
@@ -52,7 +52,7 @@ Examples:
 			return
 		}
 
-		tokenType, token, err := utils.GetAccessToken()
+		tokenType, token, err := utils.GetAccessToken(false)
 		if err != nil {
 			fmt.Fprintln(os.Stderr, "Error: "+err.Error())
 			os.Exit(1)

--- a/cmd/cluster_debug_pod.go
+++ b/cmd/cluster_debug_pod.go
@@ -14,7 +14,7 @@ var clusterDebugPodCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Capture(cmd)
 
-		tokenType, token, err := utils.GetAccessToken()
+		tokenType, token, err := utils.GetAccessToken(false)
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)

--- a/cmd/cluster_deploy.go
+++ b/cmd/cluster_deploy.go
@@ -16,7 +16,7 @@ var clusterDeployCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Capture(cmd)
 
-		tokenType, token, err := utils.GetAccessToken()
+		tokenType, token, err := utils.GetAccessToken(false)
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)

--- a/cmd/cluster_install.go
+++ b/cmd/cluster_install.go
@@ -22,7 +22,7 @@ var clusterInstallCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Capture(cmd)
 
-		tokenType, token, err := utils.GetAccessToken()
+		tokenType, token, err := utils.GetAccessToken(false)
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)

--- a/cmd/cluster_list.go
+++ b/cmd/cluster_list.go
@@ -19,7 +19,7 @@ var clusterListCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Capture(cmd)
 
-		tokenType, token, err := utils.GetAccessToken()
+		tokenType, token, err := utils.GetAccessToken(false)
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)

--- a/cmd/cluster_lock.go
+++ b/cmd/cluster_lock.go
@@ -38,7 +38,7 @@ func lockCluster() {
 	}
 
 	if utils.Validate("lock") {
-		tokenType, token, err := utils.GetAccessToken()
+		tokenType, token, err := utils.GetAccessToken(false)
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)

--- a/cmd/cluster_locked.go
+++ b/cmd/cluster_locked.go
@@ -31,7 +31,7 @@ func init() {
 }
 
 func clusterLocked() {
-	tokenType, token, err := utils.GetAccessToken()
+	tokenType, token, err := utils.GetAccessToken(false)
 	if err != nil {
 		utils.PrintlnError(err)
 		os.Exit(1)

--- a/cmd/cluster_nodes.go
+++ b/cmd/cluster_nodes.go
@@ -23,7 +23,7 @@ var clusterListNodesCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Capture(cmd)
 
-		tokenType, token, err := utils.GetAccessToken()
+		tokenType, token, err := utils.GetAccessToken(false)
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)
@@ -89,7 +89,7 @@ func ExecListNodes(req *ListNodesRequest) (*ListNodeResponse, error) {
 	pattern := regexp.MustCompile("%5B([0-9]+)%5D=")
 	wsURL.RawQuery = pattern.ReplaceAllString(command.Encode(), "[${1}]=")
 
-	tokenType, token, err := utils.GetAccessToken()
+	tokenType, token, err := utils.GetAccessToken(false)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/cluster_stop.go
+++ b/cmd/cluster_stop.go
@@ -15,7 +15,7 @@ var clusterStopCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Capture(cmd)
 
-		tokenType, token, err := utils.GetAccessToken()
+		tokenType, token, err := utils.GetAccessToken(false)
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)

--- a/cmd/cluster_unlock.go
+++ b/cmd/cluster_unlock.go
@@ -26,7 +26,7 @@ func init() {
 
 func unlockCluster() {
 	if utils.Validate("unlock") {
-		tokenType, token, err := utils.GetAccessToken()
+		tokenType, token, err := utils.GetAccessToken(false)
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)

--- a/cmd/cluster_upgrade_to_next_kubernetes_version.go
+++ b/cmd/cluster_upgrade_to_next_kubernetes_version.go
@@ -24,7 +24,7 @@ var clusterUpgradeCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Capture(cmd)
 
-		tokenType, token, err := utils.GetAccessToken()
+		tokenType, token, err := utils.GetAccessToken(false)
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)

--- a/cmd/container_cancel.go
+++ b/cmd/container_cancel.go
@@ -16,7 +16,7 @@ var containerCancelCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Capture(cmd)
 
-		tokenType, token, err := utils.GetAccessToken()
+		tokenType, token, err := utils.GetAccessToken(false)
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)

--- a/cmd/container_clone.go
+++ b/cmd/container_clone.go
@@ -20,7 +20,7 @@ var containerCloneCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Capture(cmd)
 
-		tokenType, token, err := utils.GetAccessToken()
+		tokenType, token, err := utils.GetAccessToken(false)
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)

--- a/cmd/container_create.go
+++ b/cmd/container_create.go
@@ -26,7 +26,7 @@ var containerCreateCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Capture(cmd)
 
-		tokenType, token, err := utils.GetAccessToken()
+		tokenType, token, err := utils.GetAccessToken(false)
 		utils.CheckError(err)
 
 		client := utils.GetQoveryClient(tokenType, token)

--- a/cmd/container_domain_create.go
+++ b/cmd/container_domain_create.go
@@ -20,7 +20,7 @@ var containerDomainCreateCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Capture(cmd)
 
-		tokenType, token, err := utils.GetAccessToken()
+		tokenType, token, err := utils.GetAccessToken(false)
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)

--- a/cmd/container_domain_delete.go
+++ b/cmd/container_domain_delete.go
@@ -17,7 +17,7 @@ var containerDomainDeleteCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Capture(cmd)
 
-		tokenType, token, err := utils.GetAccessToken()
+		tokenType, token, err := utils.GetAccessToken(false)
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)

--- a/cmd/container_domain_edit.go
+++ b/cmd/container_domain_edit.go
@@ -19,7 +19,7 @@ var containerDomainEditCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Capture(cmd)
 
-		tokenType, token, err := utils.GetAccessToken()
+		tokenType, token, err := utils.GetAccessToken(false)
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)

--- a/cmd/container_domain_list.go
+++ b/cmd/container_domain_list.go
@@ -20,7 +20,7 @@ var containerDomainListCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Capture(cmd)
 
-		tokenType, token, err := utils.GetAccessToken()
+		tokenType, token, err := utils.GetAccessToken(false)
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)

--- a/cmd/container_env_alias_create.go
+++ b/cmd/container_env_alias_create.go
@@ -17,7 +17,7 @@ var containerEnvAliasCreateCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Capture(cmd)
 
-		tokenType, token, err := utils.GetAccessToken()
+		tokenType, token, err := utils.GetAccessToken(false)
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)

--- a/cmd/container_env_create.go
+++ b/cmd/container_env_create.go
@@ -17,7 +17,7 @@ var containerEnvCreateCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Capture(cmd)
 
-		tokenType, token, err := utils.GetAccessToken()
+		tokenType, token, err := utils.GetAccessToken(false)
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)

--- a/cmd/container_env_delete.go
+++ b/cmd/container_env_delete.go
@@ -17,7 +17,7 @@ var containerEnvDeleteCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Capture(cmd)
 
-		tokenType, token, err := utils.GetAccessToken()
+		tokenType, token, err := utils.GetAccessToken(false)
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)

--- a/cmd/container_env_list.go
+++ b/cmd/container_env_list.go
@@ -15,7 +15,7 @@ var containerEnvListCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Capture(cmd)
 
-		tokenType, token, err := utils.GetAccessToken()
+		tokenType, token, err := utils.GetAccessToken(false)
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)

--- a/cmd/container_env_override_create.go
+++ b/cmd/container_env_override_create.go
@@ -17,7 +17,7 @@ var containerEnvOverrideCreateCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Capture(cmd)
 
-		tokenType, token, err := utils.GetAccessToken()
+		tokenType, token, err := utils.GetAccessToken(false)
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)

--- a/cmd/container_env_update.go
+++ b/cmd/container_env_update.go
@@ -17,7 +17,7 @@ var containerEnvUpdateCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Capture(cmd)
 
-		tokenType, token, err := utils.GetAccessToken()
+		tokenType, token, err := utils.GetAccessToken(false)
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)

--- a/cmd/container_external_secret_create.go
+++ b/cmd/container_external_secret_create.go
@@ -17,7 +17,7 @@ var containerExternalSecretCreateCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Capture(cmd)
 
-		tokenType, token, err := utils.GetAccessToken()
+		tokenType, token, err := utils.GetAccessToken(false)
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)

--- a/cmd/container_external_secret_delete.go
+++ b/cmd/container_external_secret_delete.go
@@ -17,7 +17,7 @@ var containerExternalSecretDeleteCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Capture(cmd)
 
-		tokenType, token, err := utils.GetAccessToken()
+		tokenType, token, err := utils.GetAccessToken(false)
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)

--- a/cmd/container_external_secret_update.go
+++ b/cmd/container_external_secret_update.go
@@ -17,7 +17,7 @@ var containerExternalSecretUpdateCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Capture(cmd)
 
-		tokenType, token, err := utils.GetAccessToken()
+		tokenType, token, err := utils.GetAccessToken(false)
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)

--- a/cmd/container_list.go
+++ b/cmd/container_list.go
@@ -15,7 +15,7 @@ var containerListCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Capture(cmd)
 
-		tokenType, token, err := utils.GetAccessToken()
+		tokenType, token, err := utils.GetAccessToken(false)
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)

--- a/cmd/container_registry_list.go
+++ b/cmd/container_registry_list.go
@@ -16,7 +16,7 @@ var containerRegistryListCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Capture(cmd)
 
-		tokenType, token, err := utils.GetAccessToken()
+		tokenType, token, err := utils.GetAccessToken(false)
 		utils.CheckError(err)
 
 		client := utils.GetQoveryClient(tokenType, token)

--- a/cmd/container_update.go
+++ b/cmd/container_update.go
@@ -19,7 +19,7 @@ var containerUpdateCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Capture(cmd)
 
-		tokenType, token, err := utils.GetAccessToken()
+		tokenType, token, err := utils.GetAccessToken(false)
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)

--- a/cmd/cronjob_cancel.go
+++ b/cmd/cronjob_cancel.go
@@ -16,7 +16,7 @@ var cronjobCancelCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Capture(cmd)
 
-		tokenType, token, err := utils.GetAccessToken()
+		tokenType, token, err := utils.GetAccessToken(false)
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)

--- a/cmd/cronjob_clone.go
+++ b/cmd/cronjob_clone.go
@@ -20,7 +20,7 @@ var cronjobCloneCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Capture(cmd)
 
-		tokenType, token, err := utils.GetAccessToken()
+		tokenType, token, err := utils.GetAccessToken(false)
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)

--- a/cmd/cronjob_env_alias_create.go
+++ b/cmd/cronjob_env_alias_create.go
@@ -17,7 +17,7 @@ var cronjobEnvAliasCreateCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Capture(cmd)
 
-		tokenType, token, err := utils.GetAccessToken()
+		tokenType, token, err := utils.GetAccessToken(false)
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)

--- a/cmd/cronjob_env_create.go
+++ b/cmd/cronjob_env_create.go
@@ -17,7 +17,7 @@ var cronjobEnvCreateCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Capture(cmd)
 
-		tokenType, token, err := utils.GetAccessToken()
+		tokenType, token, err := utils.GetAccessToken(false)
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)

--- a/cmd/cronjob_env_delete.go
+++ b/cmd/cronjob_env_delete.go
@@ -17,7 +17,7 @@ var cronjobEnvDeleteCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Capture(cmd)
 
-		tokenType, token, err := utils.GetAccessToken()
+		tokenType, token, err := utils.GetAccessToken(false)
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)

--- a/cmd/cronjob_env_list.go
+++ b/cmd/cronjob_env_list.go
@@ -15,7 +15,7 @@ var cronjobEnvListCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Capture(cmd)
 
-		tokenType, token, err := utils.GetAccessToken()
+		tokenType, token, err := utils.GetAccessToken(false)
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)

--- a/cmd/cronjob_env_override_create.go
+++ b/cmd/cronjob_env_override_create.go
@@ -17,7 +17,7 @@ var cronjobEnvOverrideCreateCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Capture(cmd)
 
-		tokenType, token, err := utils.GetAccessToken()
+		tokenType, token, err := utils.GetAccessToken(false)
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)

--- a/cmd/cronjob_env_update.go
+++ b/cmd/cronjob_env_update.go
@@ -17,7 +17,7 @@ var cronjobEnvUpdateCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Capture(cmd)
 
-		tokenType, token, err := utils.GetAccessToken()
+		tokenType, token, err := utils.GetAccessToken(false)
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)

--- a/cmd/cronjob_external_secret_create.go
+++ b/cmd/cronjob_external_secret_create.go
@@ -17,7 +17,7 @@ var cronjobExternalSecretCreateCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Capture(cmd)
 
-		tokenType, token, err := utils.GetAccessToken()
+		tokenType, token, err := utils.GetAccessToken(false)
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)

--- a/cmd/cronjob_external_secret_delete.go
+++ b/cmd/cronjob_external_secret_delete.go
@@ -17,7 +17,7 @@ var cronjobExternalSecretDeleteCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Capture(cmd)
 
-		tokenType, token, err := utils.GetAccessToken()
+		tokenType, token, err := utils.GetAccessToken(false)
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)

--- a/cmd/cronjob_external_secret_update.go
+++ b/cmd/cronjob_external_secret_update.go
@@ -17,7 +17,7 @@ var cronjobExternalSecretUpdateCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Capture(cmd)
 
-		tokenType, token, err := utils.GetAccessToken()
+		tokenType, token, err := utils.GetAccessToken(false)
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)

--- a/cmd/cronjob_list.go
+++ b/cmd/cronjob_list.go
@@ -17,7 +17,7 @@ var cronjobListCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Capture(cmd)
 
-		tokenType, token, err := utils.GetAccessToken()
+		tokenType, token, err := utils.GetAccessToken(false)
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)

--- a/cmd/cronjob_update.go
+++ b/cmd/cronjob_update.go
@@ -19,7 +19,7 @@ var cronjobUpdateCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Capture(cmd)
 
-		tokenType, token, err := utils.GetAccessToken()
+		tokenType, token, err := utils.GetAccessToken(false)
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)

--- a/cmd/database_list.go
+++ b/cmd/database_list.go
@@ -17,7 +17,7 @@ var databaseListCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Capture(cmd)
 
-		tokenType, token, err := utils.GetAccessToken()
+		tokenType, token, err := utils.GetAccessToken(false)
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)

--- a/cmd/demo_destroy.go
+++ b/cmd/demo_destroy.go
@@ -19,7 +19,7 @@ var demoDestroyCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Capture(cmd)
 
-		_, token, err := utils.GetAccessToken()
+		_, token, err := utils.GetAccessToken(false)
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)

--- a/cmd/demo_up.go
+++ b/cmd/demo_up.go
@@ -32,7 +32,7 @@ var demoUpCmd = &cobra.Command{
 			panic("unreachable") // staticcheck false positive: https://staticcheck.io/docs/checks#SA5011
 		}
 
-		tokenType, token, err := utils.GetAccessToken()
+		tokenType, token, err := utils.GetAccessToken(false)
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)

--- a/cmd/environment_cancel.go
+++ b/cmd/environment_cancel.go
@@ -17,7 +17,7 @@ var environmentCancelCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Capture(cmd)
 
-		tokenType, token, err := utils.GetAccessToken()
+		tokenType, token, err := utils.GetAccessToken(false)
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)

--- a/cmd/environment_clone.go
+++ b/cmd/environment_clone.go
@@ -18,7 +18,7 @@ var environmentCloneCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Capture(cmd)
 
-		tokenType, token, err := utils.GetAccessToken()
+		tokenType, token, err := utils.GetAccessToken(false)
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)

--- a/cmd/environment_deployment_explain.go
+++ b/cmd/environment_deployment_explain.go
@@ -27,7 +27,7 @@ var environmentDeploymentExplainCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Capture(cmd)
 
-		tokenType, token, err := utils.GetAccessToken()
+		tokenType, token, err := utils.GetAccessToken(false)
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)

--- a/cmd/environment_deployment_list.go
+++ b/cmd/environment_deployment_list.go
@@ -15,7 +15,7 @@ var environmentDeploymentListCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Capture(cmd)
 
-		tokenType, token, err := utils.GetAccessToken()
+		tokenType, token, err := utils.GetAccessToken(false)
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)

--- a/cmd/environment_env_alias_create.go
+++ b/cmd/environment_env_alias_create.go
@@ -17,7 +17,7 @@ var environmentEnvAliasCreateCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Capture(cmd)
 
-		tokenType, token, err := utils.GetAccessToken()
+		tokenType, token, err := utils.GetAccessToken(false)
 		checkError(err)
 
 		client := utils.GetQoveryClient(tokenType, token)

--- a/cmd/environment_env_create.go
+++ b/cmd/environment_env_create.go
@@ -17,7 +17,7 @@ var environmentEnvCreateCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Capture(cmd)
 
-		tokenType, token, err := utils.GetAccessToken()
+		tokenType, token, err := utils.GetAccessToken(false)
 		checkError(err)
 
 		client := utils.GetQoveryClient(tokenType, token)

--- a/cmd/environment_env_delete.go
+++ b/cmd/environment_env_delete.go
@@ -17,7 +17,7 @@ var environmentEnvDeleteCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Capture(cmd)
 
-		tokenType, token, err := utils.GetAccessToken()
+		tokenType, token, err := utils.GetAccessToken(false)
 		checkError(err)
 
 		client := utils.GetQoveryClient(tokenType, token)

--- a/cmd/environment_env_list.go
+++ b/cmd/environment_env_list.go
@@ -16,7 +16,7 @@ var environmentEnvListCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Capture(cmd)
 
-		tokenType, token, err := utils.GetAccessToken()
+		tokenType, token, err := utils.GetAccessToken(false)
 		checkError(err)
 
 		client := utils.GetQoveryClient(tokenType, token)

--- a/cmd/environment_env_override_create.go
+++ b/cmd/environment_env_override_create.go
@@ -17,7 +17,7 @@ var environmentEnvOverrideCreateCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Capture(cmd)
 
-		tokenType, token, err := utils.GetAccessToken()
+		tokenType, token, err := utils.GetAccessToken(false)
 		checkError(err)
 
 		client := utils.GetQoveryClient(tokenType, token)

--- a/cmd/environment_env_update.go
+++ b/cmd/environment_env_update.go
@@ -17,7 +17,7 @@ var environmentEnvUpdateCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Capture(cmd)
 
-		tokenType, token, err := utils.GetAccessToken()
+		tokenType, token, err := utils.GetAccessToken(false)
 		checkError(err)
 
 		client := utils.GetQoveryClient(tokenType, token)

--- a/cmd/environment_external_secret_create.go
+++ b/cmd/environment_external_secret_create.go
@@ -17,7 +17,7 @@ var environmentExternalSecretCreateCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Capture(cmd)
 
-		tokenType, token, err := utils.GetAccessToken()
+		tokenType, token, err := utils.GetAccessToken(false)
 		checkError(err)
 
 		client := utils.GetQoveryClient(tokenType, token)

--- a/cmd/environment_external_secret_delete.go
+++ b/cmd/environment_external_secret_delete.go
@@ -17,7 +17,7 @@ var environmentExternalSecretDeleteCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Capture(cmd)
 
-		tokenType, token, err := utils.GetAccessToken()
+		tokenType, token, err := utils.GetAccessToken(false)
 		checkError(err)
 
 		client := utils.GetQoveryClient(tokenType, token)

--- a/cmd/environment_external_secret_update.go
+++ b/cmd/environment_external_secret_update.go
@@ -17,7 +17,7 @@ var environmentExternalSecretUpdateCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Capture(cmd)
 
-		tokenType, token, err := utils.GetAccessToken()
+		tokenType, token, err := utils.GetAccessToken(false)
 		checkError(err)
 
 		client := utils.GetQoveryClient(tokenType, token)

--- a/cmd/environment_list.go
+++ b/cmd/environment_list.go
@@ -16,7 +16,7 @@ var environmentListCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Capture(cmd)
 
-		tokenType, token, err := utils.GetAccessToken()
+		tokenType, token, err := utils.GetAccessToken(false)
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)

--- a/cmd/environment_stage_create.go
+++ b/cmd/environment_stage_create.go
@@ -14,7 +14,7 @@ var environmentStageCreateCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Capture(cmd)
 
-		tokenType, token, err := utils.GetAccessToken()
+		tokenType, token, err := utils.GetAccessToken(false)
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)

--- a/cmd/environment_stage_delete.go
+++ b/cmd/environment_stage_delete.go
@@ -15,7 +15,7 @@ var environmentStageDeleteCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Capture(cmd)
 
-		tokenType, token, err := utils.GetAccessToken()
+		tokenType, token, err := utils.GetAccessToken(false)
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)

--- a/cmd/environment_stage_edit.go
+++ b/cmd/environment_stage_edit.go
@@ -14,7 +14,7 @@ var environmentStageEditCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Capture(cmd)
 
-		tokenType, token, err := utils.GetAccessToken()
+		tokenType, token, err := utils.GetAccessToken(false)
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)

--- a/cmd/environment_stage_list.go
+++ b/cmd/environment_stage_list.go
@@ -17,7 +17,7 @@ var environmentStageListCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Capture(cmd)
 
-		tokenType, token, err := utils.GetAccessToken()
+		tokenType, token, err := utils.GetAccessToken(false)
 		utils.CheckError(err)
 
 		client := utils.GetQoveryClient(tokenType, token)

--- a/cmd/environment_stage_move.go
+++ b/cmd/environment_stage_move.go
@@ -15,7 +15,7 @@ var environmentStageMoveCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Capture(cmd)
 
-		tokenType, token, err := utils.GetAccessToken()
+		tokenType, token, err := utils.GetAccessToken(false)
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)

--- a/cmd/environment_stage_skip.go
+++ b/cmd/environment_stage_skip.go
@@ -16,7 +16,7 @@ var environmentStageSkipCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Capture(cmd)
 
-		tokenType, token, err := utils.GetAccessToken()
+		tokenType, token, err := utils.GetAccessToken(false)
 		utils.CheckError(err)
 
 		client := utils.GetQoveryClient(tokenType, token)

--- a/cmd/environment_stage_unskip.go
+++ b/cmd/environment_stage_unskip.go
@@ -16,7 +16,7 @@ var environmentStageUnskipCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Capture(cmd)
 
-		tokenType, token, err := utils.GetAccessToken()
+		tokenType, token, err := utils.GetAccessToken(false)
 		utils.CheckError(err)
 
 		client := utils.GetQoveryClient(tokenType, token)

--- a/cmd/environment_statuses.go
+++ b/cmd/environment_statuses.go
@@ -15,7 +15,7 @@ var environmentServicesStatusesCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Capture(cmd)
 
-		tokenType, token, err := utils.GetAccessToken()
+		tokenType, token, err := utils.GetAccessToken(false)
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)

--- a/cmd/environment_update.go
+++ b/cmd/environment_update.go
@@ -17,7 +17,7 @@ var environmentUpdateCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Capture(cmd)
 
-		tokenType, token, err := utils.GetAccessToken()
+		tokenType, token, err := utils.GetAccessToken(false)
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)

--- a/cmd/helm_cancel.go
+++ b/cmd/helm_cancel.go
@@ -16,7 +16,7 @@ var helmCancelCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Capture(cmd)
 
-		tokenType, token, err := utils.GetAccessToken()
+		tokenType, token, err := utils.GetAccessToken(false)
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)

--- a/cmd/helm_clone.go
+++ b/cmd/helm_clone.go
@@ -20,7 +20,7 @@ var helmCloneCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Capture(cmd)
 
-		tokenType, token, err := utils.GetAccessToken()
+		tokenType, token, err := utils.GetAccessToken(false)
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)

--- a/cmd/helm_container_create.go
+++ b/cmd/helm_container_create.go
@@ -20,7 +20,7 @@ var helmDomainCreateCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Capture(cmd)
 
-		tokenType, token, err := utils.GetAccessToken()
+		tokenType, token, err := utils.GetAccessToken(false)
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)

--- a/cmd/helm_domain_edit.go
+++ b/cmd/helm_domain_edit.go
@@ -19,7 +19,7 @@ var helmDomainEditCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Capture(cmd)
 
-		tokenType, token, err := utils.GetAccessToken()
+		tokenType, token, err := utils.GetAccessToken(false)
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)

--- a/cmd/helm_domain_list.go
+++ b/cmd/helm_domain_list.go
@@ -20,7 +20,7 @@ var helmDomainListCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Capture(cmd)
 
-		tokenType, token, err := utils.GetAccessToken()
+		tokenType, token, err := utils.GetAccessToken(false)
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)

--- a/cmd/helm_env_alias_create.go
+++ b/cmd/helm_env_alias_create.go
@@ -17,7 +17,7 @@ var helmEnvAliasCreateCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Capture(cmd)
 
-		tokenType, token, err := utils.GetAccessToken()
+		tokenType, token, err := utils.GetAccessToken(false)
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)

--- a/cmd/helm_env_create.go
+++ b/cmd/helm_env_create.go
@@ -17,7 +17,7 @@ var helmEnvCreateCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Capture(cmd)
 
-		tokenType, token, err := utils.GetAccessToken()
+		tokenType, token, err := utils.GetAccessToken(false)
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)

--- a/cmd/helm_env_delete.go
+++ b/cmd/helm_env_delete.go
@@ -17,7 +17,7 @@ var helmEnvDeleteCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Capture(cmd)
 
-		tokenType, token, err := utils.GetAccessToken()
+		tokenType, token, err := utils.GetAccessToken(false)
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)

--- a/cmd/helm_env_list.go
+++ b/cmd/helm_env_list.go
@@ -15,7 +15,7 @@ var helmEnvListCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Capture(cmd)
 
-		tokenType, token, err := utils.GetAccessToken()
+		tokenType, token, err := utils.GetAccessToken(false)
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)

--- a/cmd/helm_env_override_create.go
+++ b/cmd/helm_env_override_create.go
@@ -17,7 +17,7 @@ var helmEnvOverrideCreateCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Capture(cmd)
 
-		tokenType, token, err := utils.GetAccessToken()
+		tokenType, token, err := utils.GetAccessToken(false)
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)

--- a/cmd/helm_env_update.go
+++ b/cmd/helm_env_update.go
@@ -17,7 +17,7 @@ var helmEnvUpdateCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Capture(cmd)
 
-		tokenType, token, err := utils.GetAccessToken()
+		tokenType, token, err := utils.GetAccessToken(false)
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)

--- a/cmd/helm_external_secret_create.go
+++ b/cmd/helm_external_secret_create.go
@@ -17,7 +17,7 @@ var helmExternalSecretCreateCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Capture(cmd)
 
-		tokenType, token, err := utils.GetAccessToken()
+		tokenType, token, err := utils.GetAccessToken(false)
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)

--- a/cmd/helm_external_secret_delete.go
+++ b/cmd/helm_external_secret_delete.go
@@ -17,7 +17,7 @@ var helmExternalSecretDeleteCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Capture(cmd)
 
-		tokenType, token, err := utils.GetAccessToken()
+		tokenType, token, err := utils.GetAccessToken(false)
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)

--- a/cmd/helm_external_secret_update.go
+++ b/cmd/helm_external_secret_update.go
@@ -17,7 +17,7 @@ var helmExternalSecretUpdateCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Capture(cmd)
 
-		tokenType, token, err := utils.GetAccessToken()
+		tokenType, token, err := utils.GetAccessToken(false)
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)

--- a/cmd/helm_list.go
+++ b/cmd/helm_list.go
@@ -15,7 +15,7 @@ var helmListCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Capture(cmd)
 
-		tokenType, token, err := utils.GetAccessToken()
+		tokenType, token, err := utils.GetAccessToken(false)
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)

--- a/cmd/helm_update.go
+++ b/cmd/helm_update.go
@@ -20,7 +20,7 @@ var helmUpdateCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Capture(cmd)
 
-		tokenType, token, err := utils.GetAccessToken()
+		tokenType, token, err := utils.GetAccessToken(false)
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)

--- a/cmd/hem_domain_delete.go
+++ b/cmd/hem_domain_delete.go
@@ -17,7 +17,7 @@ var helmDomainDeleteCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Capture(cmd)
 
-		tokenType, token, err := utils.GetAccessToken()
+		tokenType, token, err := utils.GetAccessToken(false)
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)

--- a/cmd/lifecycle_cancel.go
+++ b/cmd/lifecycle_cancel.go
@@ -16,7 +16,7 @@ var lifecycleCancelCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Capture(cmd)
 
-		tokenType, token, err := utils.GetAccessToken()
+		tokenType, token, err := utils.GetAccessToken(false)
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)

--- a/cmd/lifecycle_clone.go
+++ b/cmd/lifecycle_clone.go
@@ -20,7 +20,7 @@ var lifecycleCloneCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Capture(cmd)
 
-		tokenType, token, err := utils.GetAccessToken()
+		tokenType, token, err := utils.GetAccessToken(false)
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)

--- a/cmd/lifecycle_env_alias_create.go
+++ b/cmd/lifecycle_env_alias_create.go
@@ -17,7 +17,7 @@ var lifecycleEnvAliasCreateCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Capture(cmd)
 
-		tokenType, token, err := utils.GetAccessToken()
+		tokenType, token, err := utils.GetAccessToken(false)
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)

--- a/cmd/lifecycle_env_create.go
+++ b/cmd/lifecycle_env_create.go
@@ -17,7 +17,7 @@ var lifecycleEnvCreateCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Capture(cmd)
 
-		tokenType, token, err := utils.GetAccessToken()
+		tokenType, token, err := utils.GetAccessToken(false)
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)

--- a/cmd/lifecycle_env_delete.go
+++ b/cmd/lifecycle_env_delete.go
@@ -17,7 +17,7 @@ var lifecycleEnvDeleteCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Capture(cmd)
 
-		tokenType, token, err := utils.GetAccessToken()
+		tokenType, token, err := utils.GetAccessToken(false)
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)

--- a/cmd/lifecycle_env_list.go
+++ b/cmd/lifecycle_env_list.go
@@ -16,7 +16,7 @@ var lifecycleEnvListCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Capture(cmd)
 
-		tokenType, token, err := utils.GetAccessToken()
+		tokenType, token, err := utils.GetAccessToken(false)
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)

--- a/cmd/lifecycle_env_override_create.go
+++ b/cmd/lifecycle_env_override_create.go
@@ -17,7 +17,7 @@ var lifecycleEnvOverrideCreateCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Capture(cmd)
 
-		tokenType, token, err := utils.GetAccessToken()
+		tokenType, token, err := utils.GetAccessToken(false)
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)

--- a/cmd/lifecycle_env_update.go
+++ b/cmd/lifecycle_env_update.go
@@ -17,7 +17,7 @@ var lifecycleEnvUpdateCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Capture(cmd)
 
-		tokenType, token, err := utils.GetAccessToken()
+		tokenType, token, err := utils.GetAccessToken(false)
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)

--- a/cmd/lifecycle_external_secret_create.go
+++ b/cmd/lifecycle_external_secret_create.go
@@ -17,7 +17,7 @@ var lifecycleExternalSecretCreateCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Capture(cmd)
 
-		tokenType, token, err := utils.GetAccessToken()
+		tokenType, token, err := utils.GetAccessToken(false)
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)

--- a/cmd/lifecycle_external_secret_delete.go
+++ b/cmd/lifecycle_external_secret_delete.go
@@ -17,7 +17,7 @@ var lifecycleExternalSecretDeleteCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Capture(cmd)
 
-		tokenType, token, err := utils.GetAccessToken()
+		tokenType, token, err := utils.GetAccessToken(false)
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)

--- a/cmd/lifecycle_external_secret_update.go
+++ b/cmd/lifecycle_external_secret_update.go
@@ -17,7 +17,7 @@ var lifecycleExternalSecretUpdateCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Capture(cmd)
 
-		tokenType, token, err := utils.GetAccessToken()
+		tokenType, token, err := utils.GetAccessToken(false)
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)

--- a/cmd/lifecycle_list.go
+++ b/cmd/lifecycle_list.go
@@ -17,7 +17,7 @@ var lifecycleListCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Capture(cmd)
 
-		tokenType, token, err := utils.GetAccessToken()
+		tokenType, token, err := utils.GetAccessToken(false)
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)

--- a/cmd/lifecycle_update.go
+++ b/cmd/lifecycle_update.go
@@ -19,7 +19,7 @@ var lifecycleUpdateCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Capture(cmd)
 
-		tokenType, token, err := utils.GetAccessToken()
+		tokenType, token, err := utils.GetAccessToken(false)
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)

--- a/cmd/log.go
+++ b/cmd/log.go
@@ -28,7 +28,7 @@ var logCmd = &cobra.Command{
 }
 
 func getLogs() string {
-	tokenType, token, err := utils.GetAccessToken()
+	tokenType, token, err := utils.GetAccessToken(false)
 	if err != nil {
 		utils.PrintlnError(err)
 		os.Exit(1)

--- a/cmd/organization_list.go
+++ b/cmd/organization_list.go
@@ -17,7 +17,7 @@ var organizationListCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Capture(cmd)
 
-		tokenType, token, err := utils.GetAccessToken()
+		tokenType, token, err := utils.GetAccessToken(false)
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)

--- a/cmd/port-forward.go
+++ b/cmd/port-forward.go
@@ -157,7 +157,7 @@ func portForwardRequestFromSelect() (*pkg.PortForwardRequest, error) {
 }
 
 func portForwardRequestFromContext(currentContext utils.QoveryContext) (*pkg.PortForwardRequest, error) {
-	tokenType, token, err := utils.GetAccessToken()
+	tokenType, token, err := utils.GetAccessToken(false)
 	if err != nil {
 		utils.PrintlnError(err)
 		os.Exit(1)

--- a/cmd/project_env_alias_create.go
+++ b/cmd/project_env_alias_create.go
@@ -15,7 +15,7 @@ var projectEnvAliasCreateCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Capture(cmd)
 
-		tokenType, token, err := utils.GetAccessToken()
+		tokenType, token, err := utils.GetAccessToken(false)
 		checkError(err)
 
 		client := utils.GetQoveryClient(tokenType, token)

--- a/cmd/project_env_create.go
+++ b/cmd/project_env_create.go
@@ -15,7 +15,7 @@ var projectEnvCreateCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Capture(cmd)
 
-		tokenType, token, err := utils.GetAccessToken()
+		tokenType, token, err := utils.GetAccessToken(false)
 		checkError(err)
 
 		client := utils.GetQoveryClient(tokenType, token)

--- a/cmd/project_env_delete.go
+++ b/cmd/project_env_delete.go
@@ -15,7 +15,7 @@ var projectEnvDeleteCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Capture(cmd)
 
-		tokenType, token, err := utils.GetAccessToken()
+		tokenType, token, err := utils.GetAccessToken(false)
 		checkError(err)
 
 		client := utils.GetQoveryClient(tokenType, token)

--- a/cmd/project_env_list.go
+++ b/cmd/project_env_list.go
@@ -13,7 +13,7 @@ var projectEnvListCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Capture(cmd)
 
-		tokenType, token, err := utils.GetAccessToken()
+		tokenType, token, err := utils.GetAccessToken(false)
 		checkError(err)
 
 		client := utils.GetQoveryClient(tokenType, token)

--- a/cmd/project_env_update.go
+++ b/cmd/project_env_update.go
@@ -15,7 +15,7 @@ var projectEnvUpdateCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Capture(cmd)
 
-		tokenType, token, err := utils.GetAccessToken()
+		tokenType, token, err := utils.GetAccessToken(false)
 		checkError(err)
 
 		client := utils.GetQoveryClient(tokenType, token)

--- a/cmd/project_list.go
+++ b/cmd/project_list.go
@@ -18,7 +18,7 @@ var projectListCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Capture(cmd)
 
-		tokenType, token, err := utils.GetAccessToken()
+		tokenType, token, err := utils.GetAccessToken(false)
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)

--- a/cmd/service_list.go
+++ b/cmd/service_list.go
@@ -33,7 +33,7 @@ var serviceListCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Capture(cmd)
 
-		tokenType, token, err := utils.GetAccessToken()
+		tokenType, token, err := utils.GetAccessToken(false)
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)

--- a/cmd/shell.go
+++ b/cmd/shell.go
@@ -83,7 +83,7 @@ var (
 )
 
 func shellRequestWithContextFlags() (*pkg.ShellRequest, error) {
-	tokenType, token, err := utils.GetAccessToken()
+	tokenType, token, err := utils.GetAccessToken(false)
 	if err != nil {
 		utils.PrintlnError(err)
 		os.Exit(1)
@@ -218,7 +218,7 @@ func shellRequestFromSelect() (*pkg.ShellRequest, error) {
 }
 
 func shellRequestFromContext(currentContext utils.QoveryContext) (*pkg.ShellRequest, error) {
-	tokenType, token, err := utils.GetAccessToken()
+	tokenType, token, err := utils.GetAccessToken(false)
 	if err != nil {
 		utils.PrintlnError(err)
 		os.Exit(1)

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -15,7 +15,7 @@ var statusCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Capture(cmd)
 
-		tokenType, token, err := utils.GetAccessToken()
+		tokenType, token, err := utils.GetAccessToken(false)
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(0)

--- a/cmd/terraform_external_secret_create.go
+++ b/cmd/terraform_external_secret_create.go
@@ -17,7 +17,7 @@ var terraformExternalSecretCreateCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Capture(cmd)
 
-		tokenType, token, err := utils.GetAccessToken()
+		tokenType, token, err := utils.GetAccessToken(false)
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)

--- a/cmd/terraform_external_secret_delete.go
+++ b/cmd/terraform_external_secret_delete.go
@@ -17,7 +17,7 @@ var terraformExternalSecretDeleteCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Capture(cmd)
 
-		tokenType, token, err := utils.GetAccessToken()
+		tokenType, token, err := utils.GetAccessToken(false)
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)

--- a/cmd/terraform_external_secret_update.go
+++ b/cmd/terraform_external_secret_update.go
@@ -17,7 +17,7 @@ var terraformExternalSecretUpdateCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Capture(cmd)
 
-		tokenType, token, err := utils.GetAccessToken()
+		tokenType, token, err := utils.GetAccessToken(false)
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)

--- a/cmd/terraform_list.go
+++ b/cmd/terraform_list.go
@@ -17,7 +17,7 @@ var terraformListCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Capture(cmd)
 
-		tokenType, token, err := utils.GetAccessToken()
+		tokenType, token, err := utils.GetAccessToken(false)
 		if err != nil {
 			utils.PrintlnError(err)
 			os.Exit(1)

--- a/cmd/token.go
+++ b/cmd/token.go
@@ -39,7 +39,7 @@ var tokenCmd = &cobra.Command{
 }
 
 func generateMachineToMachineAPIToken(tokenInformation *utils.TokenInformation) (string, error) {
-	tokenType, token, err := utils.GetAccessToken()
+	tokenType, token, err := utils.GetAccessToken(false)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/admin_cluster_services.go
+++ b/pkg/admin_cluster_services.go
@@ -156,7 +156,7 @@ func UpdateClusterDomainName(clusterId string, domain string) error {
 		return fmt.Errorf("domain cannot be empty")
 	}
 
-	tokenType, token, err := utils.GetAccessToken()
+	tokenType, token, err := utils.GetAccessToken(false)
 	if err != nil {
 		return fmt.Errorf("failed to get access token: %w", err)
 	}
@@ -224,7 +224,7 @@ func UpdateClusterDnsProvider(
 		return fmt.Errorf("provider cannot be empty")
 	}
 
-	tokenType, token, err := utils.GetAccessToken()
+	tokenType, token, err := utils.GetAccessToken(false)
 	if err != nil {
 		return fmt.Errorf("failed to get access token: %w", err)
 	}
@@ -327,7 +327,7 @@ func UpdateClusterDnsProvider(
 }
 
 func (service AdminClusterListServiceImpl) fetchClustersEligibleToUpdate() ([]ClusterDetails, error) {
-	tokenType, token, err := utils.GetAccessToken()
+	tokenType, token, err := utils.GetAccessToken(false)
 	if err != nil {
 		return nil, err
 	}
@@ -493,7 +493,7 @@ func (service AdminClusterBatchDeployServiceImpl) PrintParameters() {
 }
 
 func getQoveryClient() (*qovery.APIClient, error) {
-	tokenType, token, err := utils.GetAccessToken()
+	tokenType, token, err := utils.GetAccessToken(false)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/admin_environment_deployment_rules.go
+++ b/pkg/admin_environment_deployment_rules.go
@@ -22,7 +22,7 @@ func PublishEnvironmentDeploymentRules() error {
 }
 
 func callPublishEnvironmentDeploymentRulesApi() error {
-	tokenType, token, err := utils.GetAccessToken()
+	tokenType, token, err := utils.GetAccessToken(false)
 	if err != nil {
 		utils.PrintlnError(err)
 		os.Exit(0)

--- a/pkg/admin_load_credentials.go
+++ b/pkg/admin_load_credentials.go
@@ -96,7 +96,7 @@ type AwsStsCredentials struct {
 }
 
 func fetchAwsCredentials(roleArn string) ([]byte, error) {
-	tokenType, token, err := utils.GetAccessToken()
+	tokenType, token, err := utils.GetAccessToken(false)
 	utils.CheckError(err)
 
 	req, err := http.NewRequest(http.MethodPost, utils.GetAdminUrl()+"/aws/credentials/assume-role?role_arn="+roleArn, nil)
@@ -115,7 +115,7 @@ func fetchAwsCredentials(roleArn string) ([]byte, error) {
 }
 
 func getClusterCredentials(clusterId string) []utils.Var {
-	tokenType, token, err := utils.GetAccessToken()
+	tokenType, token, err := utils.GetAccessToken(false)
 	if err != nil {
 		utils.PrintlnError(err)
 		os.Exit(0)

--- a/pkg/admin_notify_users_cluster_failure.go
+++ b/pkg/admin_notify_users_cluster_failure.go
@@ -36,7 +36,7 @@ func NotifyUsersClusterFailure(clusterId *string) error {
 }
 
 func postWithBody(url string, bodyAsString string) (*http.Response, error) {
-	tokenType, token, err := utils.GetAccessToken()
+	tokenType, token, err := utils.GetAccessToken(false)
 	if err != nil {
 		utils.PrintlnError(err)
 		os.Exit(0)

--- a/pkg/cluster.go
+++ b/pkg/cluster.go
@@ -76,7 +76,7 @@ func GetTokenByClusterId(clusterId string, readOnly bool) string {
 }
 
 func GetQoveryClientInstance() *qovery.APIClient {
-	tokenType, token, err := utils.GetAccessToken()
+	tokenType, token, err := utils.GetAccessToken(false)
 	if err != nil {
 		utils.PrintlnError(err)
 		os.Exit(1)

--- a/pkg/delete_orga.go
+++ b/pkg/delete_orga.go
@@ -138,7 +138,7 @@ func httpDelete(url string, method string, dryRunDisabled bool) *http.Response {
 }
 
 func deleteWithBody(url string, method string, dryRunDisabled bool, body io.Reader) *http.Response {
-	tokenType, token, err := utils.GetAccessToken()
+	tokenType, token, err := utils.GetAccessToken(false)
 	if err != nil {
 		utils.PrintlnError(err)
 		os.Exit(0)

--- a/pkg/deploy.go
+++ b/pkg/deploy.go
@@ -13,7 +13,7 @@ import (
 )
 
 func execAdminRequest(url string, method string, dryRunDisabled bool, queryParams map[string]string) *http.Response {
-	tokenType, token, err := utils.GetAccessToken()
+	tokenType, token, err := utils.GetAccessToken(false)
 	if err != nil {
 		utils.PrintlnError(err)
 		os.Exit(0)

--- a/pkg/download_s3_archive.go
+++ b/pkg/download_s3_archive.go
@@ -94,7 +94,7 @@ func findOrganizationInTag(tags []ArchiveTagsResponse) *string {
 }
 
 func download(url string, executionId string) *http.Response {
-	tokenType, token, err := utils.GetAccessToken()
+	tokenType, token, err := utils.GetAccessToken(false)
 	if err != nil {
 		utils.PrintlnError(err)
 		os.Exit(0)

--- a/pkg/enterpriseconnection/enterprise_connection_service.go
+++ b/pkg/enterpriseconnection/enterprise_connection_service.go
@@ -25,7 +25,7 @@ type EnterpriseConnectionService struct {
 // NewEnterpriseConnectionService creates a new service instance with authentication
 func NewEnterpriseConnectionService(organizationName string) (*EnterpriseConnectionService, error) {
 	// Get access token and client
-	tokenType, token, err := utils.GetAccessToken()
+	tokenType, token, err := utils.GetAccessToken(false)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/lock.go
+++ b/pkg/lock.go
@@ -65,7 +65,7 @@ func LockedClusters() {
 }
 
 func listLockedClusters() *http.Response {
-	tokenType, token, err := utils.GetAccessToken()
+	tokenType, token, err := utils.GetAccessToken(false)
 	if err != nil {
 		utils.PrintlnError(err)
 		os.Exit(0)

--- a/pkg/log.go
+++ b/pkg/log.go
@@ -76,7 +76,7 @@ func createLogWebsocket(req *LogRequest) (*websocket.Conn, error) {
 		return nil, err
 	}
 
-	tokenType, token, err := utils.GetAccessToken()
+	tokenType, token, err := utils.GetAccessToken(false)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/port-forward.go
+++ b/pkg/port-forward.go
@@ -68,7 +68,7 @@ func mkWebsocketConn(req *PortForwardRequest) (*WebsocketPortForward, error) {
 	pattern := regexp.MustCompile("%5B([0-9]+)%5D=")
 	wsURL.RawQuery = pattern.ReplaceAllString(command.Encode(), "[${1}]=")
 
-	tokenType, token, err := utils.GetAccessToken()
+	tokenType, token, err := utils.GetAccessToken(false)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/service_list_pods.go
+++ b/pkg/service_list_pods.go
@@ -33,7 +33,7 @@ func ExecListPods(req *PortForwardRequest) (*ListPodResponse, error) {
 	pattern := regexp.MustCompile("%5B([0-9]+)%5D=")
 	wsURL.RawQuery = pattern.ReplaceAllString(command.Encode(), "[${1}]=")
 
-	tokenType, token, err := utils.GetAccessToken()
+	tokenType, token, err := utils.GetAccessToken(false)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/shell.go
+++ b/pkg/shell.go
@@ -193,7 +193,7 @@ func createWebsocketConn(req interface{}, path string) (*websocket.Conn, *http.R
 	pattern := regexp.MustCompile("%5B([0-9]+)%5D=")
 	wsURL.RawQuery = pattern.ReplaceAllString(command.Encode(), "[${1}]=")
 
-	tokenType, token, err := utils.GetAccessToken()
+	tokenType, token, err := utils.GetAccessToken(false)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/update.go
+++ b/pkg/update.go
@@ -47,7 +47,7 @@ func UpdateAll(dryRunDisabled bool, version string, providerKind string, paralle
 }
 
 func update(url string, method string, dryRunDisabled bool, version string, providerKind string, parallelRun int) *http.Response {
-	tokenType, token, err := utils.GetAccessToken()
+	tokenType, token, err := utils.GetAccessToken(false)
 	if err != nil {
 		utils.PrintlnError(err)
 		os.Exit(0)

--- a/utils/context.go
+++ b/utils/context.go
@@ -307,22 +307,14 @@ func checkOrgaValid(orgaList *qovery.OrganizationResponseList) error {
 	}
 }
 
-func GetAccessToken() (AccessTokenType, AccessToken, error) {
-	return getAccessToken(false)
-}
-
-// GetAccessTokenAllowNoOrg is like GetAccessToken but does not fail when the
-// user has zero organizations yet. It exists solely for the one legitimate
+// GetAccessToken returns a valid access token, refreshing it if expired.
+// skipOrgaCheck should be false for every caller except the one legitimate
 // bootstrap case where an empty org list is expected: creating the user's
 // first organization via `qovery api organization --method POST ...`
-// (documented as a first-class example in `qovery api --help`). Every other
-// caller should keep using GetAccessToken, which still guards against
-// running organization-scoped commands with no organization to scope to.
-func GetAccessTokenAllowNoOrg() (AccessTokenType, AccessToken, error) {
-	return getAccessToken(true)
-}
-
-func getAccessToken(skipOrgaCheck bool) (AccessTokenType, AccessToken, error) {
+// (documented as a first-class example in `qovery api --help`). Passing
+// true anywhere else would let organization-scoped commands run with no
+// organization to scope to.
+func GetAccessToken(skipOrgaCheck bool) (AccessTokenType, AccessToken, error) {
 	apiToken := os.Getenv("QOVERY_CLI_ACCESS_TOKEN")
 	if apiToken == "" {
 		apiToken = os.Getenv("Q_CLI_ACCESS_TOKEN")

--- a/utils/context.go
+++ b/utils/context.go
@@ -308,6 +308,21 @@ func checkOrgaValid(orgaList *qovery.OrganizationResponseList) error {
 }
 
 func GetAccessToken() (AccessTokenType, AccessToken, error) {
+	return getAccessToken(false)
+}
+
+// GetAccessTokenAllowNoOrg is like GetAccessToken but does not fail when the
+// user has zero organizations yet. It exists solely for the one legitimate
+// bootstrap case where an empty org list is expected: creating the user's
+// first organization via `qovery api organization --method POST ...`
+// (documented as a first-class example in `qovery api --help`). Every other
+// caller should keep using GetAccessToken, which still guards against
+// running organization-scoped commands with no organization to scope to.
+func GetAccessTokenAllowNoOrg() (AccessTokenType, AccessToken, error) {
+	return getAccessToken(true)
+}
+
+func getAccessToken(skipOrgaCheck bool) (AccessTokenType, AccessToken, error) {
 	apiToken := os.Getenv("QOVERY_CLI_ACCESS_TOKEN")
 	if apiToken == "" {
 		apiToken = os.Getenv("Q_CLI_ACCESS_TOKEN")
@@ -334,8 +349,10 @@ func GetAccessToken() (AccessTokenType, AccessToken, error) {
 	// check the token is valid by trying to list the organizations
 	if orgaList, _, err := GetQoveryClient("Bearer", token).OrganizationMainCallsAPI.ListOrganization(context2.Background()).Execute(); err == nil {
 		// everything is fine, return the token
-		if err = checkOrgaValid(orgaList); err != nil {
-			return "", "", err
+		if !skipOrgaCheck {
+			if err = checkOrgaValid(orgaList); err != nil {
+				return "", "", err
+			}
 		}
 		return "Bearer", token, nil
 	}
@@ -347,8 +364,10 @@ func GetAccessToken() (AccessTokenType, AccessToken, error) {
 
 	if orgaList, _, err := GetQoveryClient("Bearer", token).OrganizationMainCallsAPI.ListOrganization(context2.Background()).Execute(); err == nil {
 		// everything is fine, return the token
-		if err = checkOrgaValid(orgaList); err != nil {
-			return "", "", err
+		if !skipOrgaCheck {
+			if err = checkOrgaValid(orgaList); err != nil {
+				return "", "", err
+			}
 		}
 
 		return "Bearer", token, nil

--- a/utils/context_test.go
+++ b/utils/context_test.go
@@ -1,0 +1,99 @@
+package utils
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/qovery/qovery-client-go"
+)
+
+func TestCheckOrgaValid(t *testing.T) {
+	tests := []struct {
+		name    string
+		results []qovery.Organization
+		wantErr bool
+	}{
+		{"empty organization list returns an error", []qovery.Organization{}, true},
+		{"non-empty organization list returns nil", []qovery.Organization{{Id: "org-1", Name: "test"}}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			list := qovery.OrganizationResponseList{Results: tt.results}
+			err := checkOrgaValid(&list)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("checkOrgaValid() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+// writeTestQoveryContext writes a minimal, valid ~/.qovery/context.json under home
+// so GetCurrentContext() finds a non-expired access token without touching the
+// real user's context.
+func writeTestQoveryContext(t *testing.T, home string) {
+	t.Helper()
+	dir := filepath.Join(home, ".qovery")
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	ctx := QoveryContext{
+		AccessToken:           "test-access-token",
+		AccessTokenExpiration: time.Now().Add(time.Hour),
+		RefreshToken:          "test-refresh-token",
+	}
+	bytes, err := json.Marshal(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	contextPath := filepath.Join(dir, ContextFileName+".json")
+	if err := os.WriteFile(contextPath, bytes, ContextFilePermissions); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestGetAccessToken_SkipOrgaCheck locks in the one behavior the qovery-cli#702
+// review asked to have covered: GetAccessToken(false) must keep rejecting a
+// zero-organization account (the guard every other command relies on), while
+// GetAccessToken(true) must let that one case through — used exclusively by
+// `qovery api organization --method POST` to bootstrap a brand-new account's
+// first organization.
+func TestGetAccessToken_SkipOrgaCheck(t *testing.T) {
+	tests := []struct {
+		name          string
+		orgListJSON   string
+		skipOrgaCheck bool
+		wantErr       bool
+	}{
+		{"zero organizations, check enforced -> rejected", `{"results":[]}`, false, true},
+		{"zero organizations, check skipped -> allowed", `{"results":[]}`, true, false},
+		{"existing organization, check enforced -> allowed", `{"results":[{"id":"org-1","created_at":"2024-01-01T00:00:00Z","name":"test","plan":"BUSINESS_2025"}]}`, false, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(tt.orgListJSON))
+			}))
+			defer server.Close()
+
+			home := t.TempDir()
+			t.Setenv("HOME", home)
+			t.Setenv("QOVERY_API_URL", server.URL)
+			t.Setenv("QOVERY_CLI_ACCESS_TOKEN", "")
+			t.Setenv("Q_CLI_ACCESS_TOKEN", "")
+			writeTestQoveryContext(t, home)
+
+			_, _, err := GetAccessToken(tt.skipOrgaCheck)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("GetAccessToken(%v) error = %v, wantErr %v", tt.skipOrgaCheck, err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/utils/qovery.go
+++ b/utils/qovery.go
@@ -58,7 +58,7 @@ func WebsocketUrl() string {
 }
 
 func GetQoveryClientPanicInCaseOfError() *qovery.APIClient {
-	tokenType, token, err := GetAccessToken()
+	tokenType, token, err := GetAccessToken(false)
 	CheckError(err)
 	return GetQoveryClient(tokenType, token)
 }
@@ -93,7 +93,7 @@ func GetQoveryClient(tokenType AccessTokenType, token AccessToken) *qovery.APICl
 }
 
 func SelectRole(organization *Organization) (*Role, error) {
-	tokenType, token, err := GetAccessToken()
+	tokenType, token, err := GetAccessToken(false)
 	if err != nil {
 		return nil, err
 	}
@@ -140,7 +140,7 @@ func SelectRole(organization *Organization) (*Role, error) {
 }
 
 func SelectOrganization() (*Organization, error) {
-	tokenType, token, err := GetAccessToken()
+	tokenType, token, err := GetAccessToken(false)
 	if err != nil {
 		return nil, err
 	}
@@ -215,7 +215,7 @@ type Project struct {
 }
 
 func GetOrganizationById(id string) (*Organization, error) {
-	tokenType, token, err := GetAccessToken()
+	tokenType, token, err := GetAccessToken(false)
 	if err != nil {
 		return nil, err
 	}
@@ -237,7 +237,7 @@ func GetOrganizationById(id string) (*Organization, error) {
 }
 
 func SelectProject(organizationID Id) (*Project, error) {
-	tokenType, token, err := GetAccessToken()
+	tokenType, token, err := GetAccessToken(false)
 	if err != nil {
 		return nil, err
 	}
@@ -312,7 +312,7 @@ type Environment struct {
 }
 
 func GetProjectById(id string) (*Project, error) {
-	tokenType, token, err := GetAccessToken()
+	tokenType, token, err := GetAccessToken(false)
 	if err != nil {
 		return nil, err
 	}
@@ -334,7 +334,7 @@ func GetProjectById(id string) (*Project, error) {
 }
 
 func SelectEnvironment(projectID Id) (*Environment, error) {
-	tokenType, token, err := GetAccessToken()
+	tokenType, token, err := GetAccessToken(false)
 	if err != nil {
 		return nil, err
 	}
@@ -405,7 +405,7 @@ func SelectAndSetEnvironment(projectID Id) (*Environment, error) {
 }
 
 func GetEnvironmentById(id string) (*Environment, error) {
-	tokenType, token, err := GetAccessToken()
+	tokenType, token, err := GetAccessToken(false)
 	if err != nil {
 		return nil, err
 	}
@@ -433,7 +433,7 @@ type EnvironmentService struct {
 }
 
 func GetEnvironmentServicesById(id string) ([]EnvironmentService, error) {
-	tokenType, token, err := GetAccessToken()
+	tokenType, token, err := GetAccessToken(false)
 	if err != nil {
 		return nil, err
 	}
@@ -507,7 +507,7 @@ type Application struct {
 }
 
 func SelectService(environment Id) (*Service, error) {
-	tokenType, token, err := GetAccessToken()
+	tokenType, token, err := GetAccessToken(false)
 	if err != nil {
 		return nil, err
 	}
@@ -672,7 +672,7 @@ func SelectAndSetService(environment Id) (*Service, error) {
 }
 
 func GetApplicationById(id string) (*Application, error) {
-	tokenType, token, err := GetAccessToken()
+	tokenType, token, err := GetAccessToken(false)
 	if err != nil {
 		return nil, err
 	}
@@ -720,7 +720,7 @@ type Container struct {
 }
 
 func GetContainerById(id string) (*Container, error) {
-	tokenType, token, err := GetAccessToken()
+	tokenType, token, err := GetAccessToken(false)
 	if err != nil {
 		return nil, err
 	}
@@ -742,7 +742,7 @@ func GetContainerById(id string) (*Container, error) {
 }
 
 func GetDatabaseById(id string) (*Service, error) {
-	tokenType, token, err := GetAccessToken()
+	tokenType, token, err := GetAccessToken(false)
 	if err != nil {
 		return nil, err
 	}
@@ -765,7 +765,7 @@ func GetDatabaseById(id string) (*Service, error) {
 }
 
 func GetHelmById(id string) (*Service, error) {
-	tokenType, token, err := GetAccessToken()
+	tokenType, token, err := GetAccessToken(false)
 	if err != nil {
 		return nil, err
 	}
@@ -793,7 +793,7 @@ type Job struct {
 }
 
 func GetJobById(id string) (*Job, error) {
-	tokenType, token, err := GetAccessToken()
+	tokenType, token, err := GetAccessToken(false)
 	if err != nil {
 		return nil, err
 	}
@@ -836,7 +836,7 @@ func GetAdminUrl() string {
 }
 
 func DeleteEnvironmentVariable(application Id, key string) error {
-	tokenType, token, err := GetAccessToken()
+	tokenType, token, err := GetAccessToken(false)
 	if err != nil {
 		return err
 	}
@@ -876,7 +876,7 @@ func DeleteEnvironmentVariable(application Id, key string) error {
 }
 
 func AddEnvironmentVariable(application Id, key string, value string) error {
-	tokenType, token, err := GetAccessToken()
+	tokenType, token, err := GetAccessToken(false)
 	if err != nil {
 		return err
 	}
@@ -899,7 +899,7 @@ func AddEnvironmentVariable(application Id, key string, value string) error {
 }
 
 func DeleteSecret(application Id, key string) error {
-	tokenType, token, err := GetAccessToken()
+	tokenType, token, err := GetAccessToken(false)
 	if err != nil {
 		return err
 	}
@@ -939,7 +939,7 @@ func DeleteSecret(application Id, key string) error {
 }
 
 func AddSecret(application Id, key string, value string) error {
-	tokenType, token, err := GetAccessToken()
+	tokenType, token, err := GetAccessToken(false)
 	if err != nil {
 		return err
 	}
@@ -964,7 +964,7 @@ func AddSecret(application Id, key string, value string) error {
 // Container environment variable functions
 
 func AddContainerEnvironmentVariable(container Id, key string, value string) error {
-	tokenType, token, err := GetAccessToken()
+	tokenType, token, err := GetAccessToken(false)
 	if err != nil {
 		return err
 	}
@@ -987,7 +987,7 @@ func AddContainerEnvironmentVariable(container Id, key string, value string) err
 }
 
 func DeleteContainerEnvironmentVariable(container Id, key string) error {
-	tokenType, token, err := GetAccessToken()
+	tokenType, token, err := GetAccessToken(false)
 	if err != nil {
 		return err
 	}
@@ -1027,7 +1027,7 @@ func DeleteContainerEnvironmentVariable(container Id, key string) error {
 }
 
 func AddContainerSecret(container Id, key string, value string) error {
-	tokenType, token, err := GetAccessToken()
+	tokenType, token, err := GetAccessToken(false)
 	if err != nil {
 		return err
 	}
@@ -1050,7 +1050,7 @@ func AddContainerSecret(container Id, key string, value string) error {
 }
 
 func DeleteContainerSecret(container Id, key string) error {
-	tokenType, token, err := GetAccessToken()
+	tokenType, token, err := GetAccessToken(false)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Summary
- `GetAccessToken()` validates the token by calling `ListOrganization()` and hard-fails with *"you don't have any organization. Please create an account on https://start.qovery.com ."* whenever the list is empty — before the actual request is even sent.
- This blocks **every** `qovery api ...` call for a brand-new account, including the org-creation call itself: `qovery api organization --field name=... --field plan=...`, which `qovery api --help` documents as a first-class example.
- Net effect: a new user cannot bootstrap their first organization through the CLI at all, and has to detour through the web console just to create it — even though the CLI's own docs say otherwise.

## Fix
- Extracted the existing logic into `getAccessToken(skipOrgaCheck bool)`, keeping `GetAccessToken()` behavior unchanged for every existing caller.
- Added `GetAccessTokenAllowNoOrg()`, used only by `runAPI` (`cmd/api.go`) when the request is exactly `POST /organization` — the one legitimate case where having zero organizations is expected.
- Every other `qovery api` call (and every other command using `GetAccessToken`) keeps the existing guard against operating with no organization to scope to.

## Test plan
- [x] `go build ./cmd/... ./utils/...` and `go vet ./cmd/... ./utils/...` — clean (pre-existing `go vet ./...` failures in unrelated packages are due to missing generated mocks, unaffected by this change)
- [x] `gofmt -l cmd/api.go utils/context.go` — no diff
- [x] Manually verified end-to-end against production API with a brand-new account that had zero organizations:
  - `qovery api organization --field name="..." --field plan=BUSINESS_2025` now succeeds (`200`, returns the created org)
  - Confirmed the org is real via the Console
  - After a fresh `qovery auth --headless` (to pick up the new org's role claim in the JWT), `qovery api organization` (unpatched binary) lists it normally, and every other command continues to correctly reject zero-organization accounts

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allows `qovery api organization --method POST` to create the first organization on a new account instead of failing with "you don't have any organization" before the request is sent. `GetAccessToken()` now takes a `skipOrgaCheck bool`; every call site passes `false` except `runAPI` for the exact `POST /organization` path and `auth status`, which pass `true` so zero-organization accounts can create their first org and still be recognized as authenticated, while all other commands keep the guard.

<sup>Written for commit 64753e3b7656db8400a6739a95d46c72dbffde03. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Qovery/qovery-cli/pull/702?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

