### PR TITLE
fix(docker): retry go mod download and cache Go modules

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,13 +10,14 @@ COPY go.mod go.sum ./
 
 # Download dependencies
 # Retried: proxy.golang.org intermittently resets HTTP/2 streams mid-download.
-# Errors decidable from go.mod/go.sum alone can never succeed on retry, so they
-# fail fast; anything else is assumed transient and retried.
+# Only transport failures are worth retrying. If the proxy or VCS returned a
+# definitive answer, or the error is in local files, another attempt cannot
+# change it, so fail fast instead of sleeping through the backoff.
 RUN --mount=type=cache,target=/go/pkg/mod \
     for attempt in 1 2 3 4 5; do \
         if go mod download >/tmp/godl.log 2>&1; then exit 0; fi; \
         cat /tmp/godl.log; \
-        if grep -qE 'SECURITY ERROR|checksum mismatch|missing go.sum entry|errors parsing go.mod|invalid version' /tmp/godl.log; then \
+        if grep -qE 'SECURITY ERROR|checksum mismatch|missing go.sum entry|errors parsing go.mod|invalid version|unknown revision|malformed module path|module lookup disabled' /tmp/godl.log; then \
             echo "go mod download failed with a non-transient error; not retrying"; \
             exit 1; \
         fi; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,13 +9,23 @@ WORKDIR /app
 COPY go.mod go.sum ./
 
 # Download dependencies
-RUN go mod download
+# Retried: proxy.golang.org intermittently resets HTTP/2 streams mid-download.
+RUN --mount=type=cache,target=/go/pkg/mod \
+    for attempt in 1 2 3 4 5; do \
+        go mod download && exit 0; \
+        echo "go mod download failed (attempt ${attempt}/5)"; \
+        [ "${attempt}" = 5 ] && break; \
+        sleep $((attempt * 5)); \
+    done; \
+    exit 1
 
 # Copy the source code to the container's working directory
 COPY . .
 
 # Build the Go application
-RUN go build -o qovery -ldflags "-X github.com/qovery/qovery-cli/utils.Version=$APP_VERSION"
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    go build -o qovery -ldflags "-X github.com/qovery/qovery-cli/utils.Version=$APP_VERSION"
 
 FROM public.ecr.aws/r3m4q3r9/pub-mirror-debian:bookworm-slim as runner
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,9 +10,16 @@ COPY go.mod go.sum ./
 
 # Download dependencies
 # Retried: proxy.golang.org intermittently resets HTTP/2 streams mid-download.
+# Errors decidable from go.mod/go.sum alone can never succeed on retry, so they
+# fail fast; anything else is assumed transient and retried.
 RUN --mount=type=cache,target=/go/pkg/mod \
     for attempt in 1 2 3 4 5; do \
-        go mod download && exit 0; \
+        if go mod download >/tmp/godl.log 2>&1; then exit 0; fi; \
+        cat /tmp/godl.log; \
+        if grep -qE 'SECURITY ERROR|checksum mismatch|missing go.sum entry|errors parsing go.mod|invalid version' /tmp/godl.log; then \
+            echo "go mod download failed with a non-transient error; not retrying"; \
+            exit 1; \
+        fi; \
         echo "go mod download failed (attempt ${attempt}/5)"; \
         [ "${attempt}" = 5 ] && break; \
         sleep $((attempt * 5)); \


### PR DESCRIPTION
## Why

The `container` job of the v1.168.5 release ([run 33393047477](https://github.com/Qovery/qovery-cli/actions/runs/33393047477)) failed at `Dockerfile:12`:

```
#16 [builder 4/6] RUN go mod download
#16 60.34 go: go4.org@v0.0.0-20260112195520-a5071408f32f:
  read "https://proxy.golang.org/go4.org/@v/...mod":
  stream error: stream ID 171; INTERNAL_ERROR; received from peer
```

A transient HTTP/2 stream reset on the way to the Go module proxy. The tag itself was fine — `Build` and `Release Latest` on the same commit were green, and `go4.org` is a long-standing indirect dependency.

What turned the blip into a failed release is the builder stage, unchanged in this respect since #167 (2023): it re-fetches all 198 modules on every build with no cache and no retry, and one failed request kills the layer, the job, and the image publish. The result was a half-released v1.168.5 — GitHub release, Homebrew, Scoop, AUR and R2 artifacts published, but no Docker image, with `latest` on ECR/GHCR still pointing at v1.168.4.

## What

- Retry `go mod download` up to 5 times with linear backoff (5/10/15/20s, ~50s worst case before failing).
- Mount BuildKit caches for the Go module cache (`/go/pkg/mod`) and build cache (`/root/.cache/go-build`), on both the download and build steps.

## Notes

- `GOPROXY`'s `direct` fallback does not help here: it only applies to 404/410, not to a stream reset, so retrying is the only way to absorb this class of error.
- The cache mounts are ephemeral per runner, so in CI they only help within a single build — the retry is what protects releases. Making the cache persist across runs would mean moving the workflow to `docker/build-push-action` with `cache-to: type=gha`; happy to do that as a follow-up if wanted.
- Verified locally against `public.ecr.aws/r3m4q3r9/pub-mirror-go:1.25.1`: image builds and `qovery version` reports the injected `APP_VERSION`; retry path exercised with `GOPROXY=http://127.0.0.1:1`, which logs 5 attempts and exits 1.
- Not touched, to keep the diff scoped: the `FromAsCasing` warnings (`as` vs `AS` on the two `FROM` lines) that show up in every build log.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the Docker build resilient to transient proxy failures by retrying `go mod download` and caching Go modules, so an intermittent HTTP/2 stream reset no longer fails the release and leaves no image published.

**Bug Fixes**
- Retries `go mod download` up to 5 times with 5-second linear backoff on transport failures only.
- Mounts BuildKit caches for the Go module and build caches on the download and build steps.
- Fails immediately on non-transient errors (checksum mismatches, missing go.sum entries, go.mod parse errors, unknown revisions, malformed module paths, module lookup disabled).

<sup>Written for commit f322bd4ef3c5e244d2d0cf91e8419943b6df1b84. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Qovery/qovery-cli/pull/703?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

