### PR TITLE
chore(QOV-2223): demo bump k3s to 1.36.4

### DIFF
--- a/cmd/demo_scripts/create_qovery_demo.sh
+++ b/cmd/demo_scripts/create_qovery_demo.sh
@@ -70,6 +70,7 @@ get_or_create_cluster() {
     --k3s-arg "--disable=traefik@server:*" \
     --registry-create qovery-registry.lan \
     --port "80:80@loadbalancer" --port "443:443@loadbalancer"
+      --image 'docker.io/rancher/k3s:v1.36.4-k3s1' \
   else
     k3d cluster start "$clusterName"
   fi

--- a/cmd/demo_scripts/create_qovery_demo.sh
+++ b/cmd/demo_scripts/create_qovery_demo.sh
@@ -64,13 +64,12 @@ get_or_create_cluster() {
   if [ "$clusterExist" = "" ]
   then
     k3d cluster create "$clusterName" \
-    --image 'docker.io/rancher/k3s:v1.33.5-k3s1' \
+    --image 'docker.io/rancher/k3s:v1.36.4-k3s1' \
     --subnet '172.42.0.0/16' \
     --k3s-arg "--node-ip=172.42.0.3@server:0" \
     --k3s-arg "--disable=traefik@server:*" \
     --registry-create qovery-registry.lan \
     --port "80:80@loadbalancer" --port "443:443@loadbalancer"
-      --image 'docker.io/rancher/k3s:v1.36.4-k3s1' \
   else
     k3d cluster start "$clusterName"
   fi


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Bumps the demo k3s cluster from 1.33.5 to 1.36.4 by passing the `docker.io/rancher/k3s:v1.36.4-k3s1` image to the k3d cluster creation command. Newly created demo clusters will now run the newer k3s version.

<sup>Written for commit b394f311710bfeecff34982999d7d995f8abb884. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Qovery/qovery-cli/pull/704?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

